### PR TITLE
Continue running if github commit hash not valid

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -3,7 +3,7 @@ require 'octokit'
 # github class
 class Github
   def initialize(config, project, commit)
-    @up = false
+    @api_connected = false
     @logger = project.logger
     @target_url = project.dropbox.url
     @repo = config['repository']
@@ -18,21 +18,21 @@ class Github
     password = @credentials['password']
     @github = Octokit::Client.new(login: login, password: password)
     @logger.info("Connected to github with: #{@github.user.login}")
-    @up = true
+    @api_connected = true
   rescue Octokit::Unauthorized
     @logger.error('Github authentication failed')
     nil
   end
 
-  def up?
-    @up
+  def connected?
+    @api_connected
   end
 
   def find_pr
     pr = @github.pulls(@repo).find { |x| x['head']['sha'] == @commit }
     if pr.nil?
-      @logger.error('Pull request commit hash not valid')
-      @up = false
+      @logger.error('Pull request commit hash not valid, disconnecting github.')
+      @api_connected = false
       return nil
     end
     unless pr.nil?

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -32,6 +32,7 @@ class Github
     pr = @github.pulls(@repo).find { |x| x['head']['sha'] == @commit }
     if pr.nil?
       @logger.error('Pull request commit hash not valid')
+      @up = false
       return nil
     end
     unless pr.nil?

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -62,11 +62,12 @@ class Project
 
   def github_handling(commit)
     @github = Github.new(@config, self, commit)
-    return unless @github.up?
+    return unless @github.connected?
 
     @github.find_pr
-    @github.create_status('pending', 'Tests session initiated') if @github.up?
-    @github
+    return unless @github.connected?
+
+    @github.create_status('pending', 'Tests session initiated')
   end
 
   def validate_paths

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -65,7 +65,7 @@ class Project
     return unless @github.up?
 
     @github.find_pr
-    @github.create_status('pending', 'Tests session initiated')
+    @github.create_status('pending', 'Tests session initiated') if @github.up?
     @github
   end
 


### PR DESCRIPTION
If provided invalid GitHub commit hash the test session will not start.
this commit will allow it to continue running without github status checks

Signed-off-by: Lior Haim <lior@daynix.com>