### PR TITLE
Additional platforms configurations

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,12 @@
     "platforms_defaults": {
       "world_net_device": "e1000e",
       "ctrl_net_device": "e1000e",
-      "file_transfer_device": "e1000e"
+      "file_transfer_device": "e1000e",
+      "machine_type": "pc",
+      "s3": "on",
+      "s4": "on",
+      "enlightenments_state": "off",
+      "vhost_state": "on"
     },
     "toolshck_path": "./toolsHCK.ps1",
     "studio_username": "Administrator",

--- a/config.json
+++ b/config.json
@@ -8,6 +8,11 @@
     "id_range": [ 2, 90 ],
     "dhcp_bridge": "br1",
     "winrm_port": "5985",
+    "platforms_defaults": {
+      "world_net_device": "e1000e",
+      "ctrl_net_device": "e1000e",
+      "file_transfer_device": "e1000e"
+    },
     "toolshck_path": "./toolsHCK.ps1",
     "studio_username": "Administrator",
     "studio_password": "Qum5net.",

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "images_path": "/home/hck-ci/HCK-CI/images",
     "qemu_img": "qemu-img",
     "qemu_bin": "qemu-kvm",
+    "ivshmem_server_bin": "ivshmem-server",
     "ip_segment": "192.168.0.",
     "id_range": [ 2, 90 ],
     "dhcp_bridge": "br1",
@@ -19,6 +20,7 @@
       "vhost_state": "on"
     },
     "toolshck_path": "./toolsHCK.ps1",
+    "filesystem_tests_image": "/home/hck-ci/HCK-CI/images/filesystem_tests_image.qcow2",
     "studio_username": "Administrator",
     "studio_password": "Qum5net.",
     "repository": "daynix/kvm-guest-drivers-windows",

--- a/lib/virthck.rb
+++ b/lib/virthck.rb
@@ -36,14 +36,19 @@ class VirtHCK
     @project.workspace_path + '/' + filename + '-snapshot.qcow2'
   end
 
+  def platform_config(param)
+    default_value = @project.config['platforms_defaults'][param]
+    @project.platform[param] || default_value
+  end
+
   def base_cmd
     ["cd #{@project.config['virthck_path']} &&",
      "sudo ./hck.sh ci_mode -id #{@id}",
      "-world_bridge #{@project.config['dhcp_bridge']}",
      "-qemu_bin #{@project.config['qemu_bin']}",
-     "-ctrl_net_device #{@project.platform['ctrl_net_device']}",
-     "-world_net_device #{@project.platform['world_net_device']}",
-     "-file_transfer_device #{@project.platform['file_transfer_device']}",
+     "-ctrl_net_device #{platform_config('ctrl_net_device')}",
+     "-world_net_device #{platform_config('world_net_device')}",
+     "-file_transfer_device #{platform_config('file_transfer_device')}",
      "-st_image #{studio_snapshot}"]
   end
 

--- a/lib/virthck.rb
+++ b/lib/virthck.rb
@@ -48,7 +48,11 @@ class VirtHCK
      "-qemu_bin #{@project.config['qemu_bin']}",
      "-ctrl_net_device #{platform_config('ctrl_net_device')}",
      "-world_net_device #{platform_config('world_net_device')}",
-     "-file_transfer_device #{platform_config('file_transfer_device')}",
+     "-machine_type #{platform_config('machine_type')}",
+     "-s3 #{platform_config('s3')}",
+     "-s4 #{platform_config('s4')}",
+     "-enlightenments_state #{platform_config('enlightenments_state')}",
+     "-vhost_state #{platform_config('vhost_state')}",
      "-st_image #{studio_snapshot}"]
   end
 

--- a/lib/virthck.rb
+++ b/lib/virthck.rb
@@ -46,6 +46,8 @@ class VirtHCK
      "sudo ./hck.sh ci_mode -id #{@id}",
      "-world_bridge #{@project.config['dhcp_bridge']}",
      "-qemu_bin #{@project.config['qemu_bin']}",
+     "-ivshmem_server_bin #{@project.config['ivshmem_server_bin']}",
+     "-filesystem_tests_image #{@project.config['filesystem_tests_image']}",
      "-ctrl_net_device #{platform_config('ctrl_net_device')}",
      "-world_net_device #{platform_config('world_net_device')}",
      "-machine_type #{platform_config('machine_type')}",

--- a/platforms.json
+++ b/platforms.json
@@ -3,9 +3,6 @@
     "name": "Win7x64",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -27,9 +24,6 @@
     "name": "Win7x86",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -51,9 +45,6 @@
     "name": "Win8x64",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -75,9 +66,6 @@
     "name": "Win8x86",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -99,9 +87,6 @@
     "name": "Win81x64",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -123,9 +108,6 @@
     "name": "Win81x86",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -147,9 +129,6 @@
     "name": "Win2008R2x64",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -171,9 +150,6 @@
     "name": "Win2012x64",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -195,9 +171,6 @@
     "name": "Win2012R2x64",
     "kit": "HCK",
     "st_image": "HCK.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -219,9 +192,6 @@
     "name": "Win2016x64",
     "kit": "HLK1607",
     "st_image": "HLK1607.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -243,9 +213,6 @@
     "name": "Win10_1607x64",
     "kit": "HLK1703",
     "st_image": "HLK1703.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -267,9 +234,6 @@
     "name": "Win10_1607x86",
     "kit": "HLK1703",
     "st_image": "HLK1703.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -291,9 +255,6 @@
     "name": "Win10_1703x64",
     "kit": "HLK1703",
     "st_image": "HLK1703.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -315,9 +276,6 @@
     "name": "Win10_1703x86",
     "kit": "HLK1703",
     "st_image": "HLK1703.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -339,9 +297,6 @@
     "name": "Win10_1709x64",
     "kit": "HLK1709",
     "st_image": "HLK1709.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -363,9 +318,6 @@
     "name": "Win10_1709x86",
     "kit": "HLK1709",
     "st_image": "HLK1709.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -387,9 +339,6 @@
     "name": "Win10_1803x64",
     "kit": "HLK1803",
     "st_image": "HLK1803.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -411,9 +360,6 @@
     "name": "Win10_1803x86",
     "kit": "HLK1803",
     "st_image": "HLK1803.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -435,9 +381,6 @@
     "name": "Win10_1809x86",
     "kit": "HLK1809",
     "st_image": "HLK1809.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -459,9 +402,6 @@
     "name": "Win10_1809x64",
     "kit": "HLK1809",
     "st_image": "HLK1809.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",
@@ -483,9 +423,6 @@
     "name": "Win2019x64",
     "kit": "HLK1809",
     "st_image": "HLK1809.qcow2",
-    "world_net_device": "e1000e",
-    "ctrl_net_device": "e1000e",
-    "file_transfer_device": "e1000e",
     "clients": {
       "c1": {
         "name": "CL1",


### PR DESCRIPTION
This series adds additional configurations with the possibility to use default values on platforms configurations when not specified.

platform configurations:
* machine_type
* s3
* s4
* enlightenments_state
* vhost_state

general configurations:
* ivshmem_server_bin
* filesystem_tests_image