### PR TITLE
Adding 'Run RSC Tests' to 'Red Hat VirtIO Ethernet Adapter' blacklist

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -8,7 +8,8 @@
     "support": true,
     "blacklist": [
       "NDISTest 6.0 - [2 Machine] - 2c_Mini6RSSSendRecv",
-      "NDISTest 6.5 - [2 Machine] - MPE_Ethernet.xml"
+      "NDISTest 6.5 - [2 Machine] - MPE_Ethernet.xml",
+      "Run RSC Tests"
     ]
   },
   {


### PR DESCRIPTION
This test fails but never returns which causes a stall to our testing
progress, putting it in the blacklist until the issue is fixed.

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>