### PR TITLE
Updating blacklist/playlist format to support multiple platforms

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -6,11 +6,48 @@
     "inf": "netkvm.inf",
     "install_method": "PNP",
     "support": true,
-    "blacklist": [
-      "NDISTest 6.0 - [2 Machine] - 2c_Mini6RSSSendRecv",
-      "NDISTest 6.5 - [2 Machine] - MPE_Ethernet.xml",
-      "Run RSC Tests"
-    ]
+    "blacklists": {
+      "Win7x86":
+        [],
+      "Win7x64":
+        [],
+      "Win8x86":
+        [],
+      "Win8x64":
+        [],
+      "Win8.1x64":
+        [],
+      "Win8.1x86":
+        [],
+      "Win2012x64":
+        [],
+      "Win2012R2x64":
+        [],
+      "Win2016x64":
+        [],
+      "Win2019x64":
+        [],
+      "Win10_1607x64":
+        [],
+      "Win10_1607x86":
+        [],
+      "Win10_1703x64":
+        [],
+      "Win10_1703x86":
+        [],
+      "Win10_1709x64":
+        [],
+      "Win10_1709x86":
+        [],
+      "Win10_1803x64":
+        [],
+      "Win10_1803x86":
+        [],
+      "Win10_1809x64":
+        [],
+      "Win10_1809x86":
+        []
+    }
   },
   {
     "name": "Red Hat VirtIO SCSI Disk Device",

--- a/lib/playlist.rb
+++ b/lib/playlist.rb
@@ -39,7 +39,8 @@ class Playlist
   end
 
   def custom_playlist(log)
-    playlist = @project.device['playlist']
+    platform = @project.platform['name']
+    playlist = @project.device['playlists'][platform]
     return unless playlist
 
     @tests.select! { |test| playlist.include?(test['name']) }
@@ -48,7 +49,10 @@ class Playlist
   end
 
   def custom_blacklist(log)
-    blacklist = @project.device['blacklist']
+    platform = @project.platform['name']
+    blacklist = @project.device['blacklists'][platform]
+    return unless blacklist
+
     @tests.reject! { |test| blacklist.include?(test['name']) } if blacklist
     @logger.info('Applying custom blacklist') if log && blacklist
   end


### PR DESCRIPTION
This commit allows us to specify a different blacklist/playlist for platform.

The virtio-win example blacklist was cleared so it can be refilled with acurate playlist.

Signed-off-by: Lior Haim <lior@daynix.com>