### PR TITLE
Schedule options as strings

### DIFF
--- a/lib/tests.rb
+++ b/lib/tests.rb
@@ -19,7 +19,7 @@ class Tests
   end
 
   def support_needed?(test)
-    (test['scheduleoptions'] & %w[6 RequiresMultipleMachines]) != []
+    test['scheduleoptions'].include?('RequiresMultipleMachines')
   end
 
   def test_support(test)


### PR DESCRIPTION
toolsHCK was updates to use strings instead of ids

Signed-off-by: Lior Haim <lior@daynix.com>