### PR TITLE
Fix support keep alive after concurrent test update

### DIFF
--- a/lib/tests.rb
+++ b/lib/tests.rb
@@ -104,7 +104,7 @@ InQueue: #{stats['inqueue']}")
 
   def keep_clients_alive
     @client.keep_alive
-    @support.keep_alive if @support
+    @support.keep_alive
   end
 
   def new_done


### PR DESCRIPTION
This commit fixes a bug where AutoHCK won't start again support machine after shutdown.
Signed-off-by: Lior Haim <lior@daynix.com>