### PR TITLE
Revert "Schedule options as strings"

### DIFF
--- a/lib/tests.rb
+++ b/lib/tests.rb
@@ -19,7 +19,7 @@ class Tests
   end
 
   def support_needed?(test)
-    test['scheduleoptions'].include?('RequiresMultipleMachines')
+    (test['scheduleoptions'] & %w[6 RequiresMultipleMachines]) != []
   end
 
   def test_support(test)


### PR DESCRIPTION
reverting due to a change made to toolsHCK and wasn't working as expected.
This reverts commit 2ebdb8b6b07f061aaee6134766ac08595a49f85f.