### PR TITLE
Proofing the Monitor instance of a Client

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -17,6 +17,7 @@ class Client
     @logger = project.logger
     @studio = studio
     @virthck = project.virthck
+    @monitor = Monitor.new(@project, @id)
     create_snapshot
   end
 
@@ -67,7 +68,6 @@ class Client
   end
 
   def shutdown_machine
-    @monitor = Monitor.new(@project, @id)
     @monitor.powerdown
   end
 

--- a/lib/monitor.rb
+++ b/lib/monitor.rb
@@ -9,13 +9,9 @@ class Monitor
   def initialize(project, id)
     @virthck_id = project.virthck.id
     client_id = 3 * @virthck_id.to_i - 2 + id.to_i
-    port = MONITOR_BASE_PORT + client_id
+    @port = MONITOR_BASE_PORT + client_id
     @logger = project.logger
     @logger.info('Initiating qemu-monitor session')
-    @monitor = Net::Telnet.new('Host' => LOCALHOST,
-                               'Port' => port,
-                               'Timeout' => TIMEOUT,
-                               'Prompt' => /\(qemu\)/)
   end
 
   def powerdown
@@ -29,7 +25,12 @@ class Monitor
   end
 
   def cmd(cmd)
-    @monitor.cmd(cmd)
+    monitor = Net::Telnet.new('Host' => LOCALHOST,
+                              'Port' => @port,
+                              'Timeout' => TIMEOUT,
+                              'Prompt' => /\(qemu\)/)
+    monitor.cmd(cmd)
+    monitor.close
   rescue Net::ReadTimeout, Errno::ECONNRESET
     @logger.error('Monitor not responding')
   end


### PR DESCRIPTION
Initializing a Monitor instance on shutdown_machine method call is not a good practice.
The idea behind this implementation is that sometimes the machines do shutdown and the Monitor instance would be invalid if initialized in the constructor of a Client instance.
This commit changes:
1. The behavior of a Monitor class without changing its functionality. (a telnet session is initialized on each action call then it is closed)
2. Moves the initialization of Monitor instance to the constructor of Client.