### PR TITLE
Fixing VirtHCK system command call

### DIFF
--- a/lib/virthck.rb
+++ b/lib/virthck.rb
@@ -90,7 +90,7 @@ class VirtHCK
   end
 
   def run_cmd(cmd)
-    system(cmd)
+    system(cmd.join(' '))
   end
 
   def create_client_snapshot(name)


### PR DESCRIPTION
cmd variable is an array of strings, join is required before system
command call.

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>