### PR TITLE
Archiving test result logs failure behavior update

### DIFF
--- a/lib/tests.rb
+++ b/lib/tests.rb
@@ -78,6 +78,8 @@ InQueue: #{stats['inqueue']}")
     new_filename = res['status'] + ': ' + res['testname']
     update_remote(res['hostlogszippath'], new_filename)
     @logger.info('Test archive uploaded via the result uploader')
+  rescue Tools::ZipTestResultLogsError
+    @logger.info('Skipping archiving test result logs')
   end
 
   def update_remote(test_logs_path, test_name)


### PR DESCRIPTION
Failed test result logs archive will not fail the AutoHCK run anymore, and
will only skip the archiving and log a corresponding message to indicate
this behavior.

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>