### PR TITLE
Old Test result removal

### DIFF
--- a/lib/dropbox.rb
+++ b/lib/dropbox.rb
@@ -58,5 +58,16 @@ class Dropbox
     @logger.error("Dropbox update_file_content error: #{e.message}")
   end
 
+  def delete_file(r_name)
+    return false if @dropbox.nil?
+
+    r_path = @path + '/' + r_name
+    @dropbox.delete(r_path)
+    @logger.info("Dropbox file deleted: #{r_path}")
+    true
+  rescue DropboxApi::Errors::NotFoundError
+    false
+  end
+
   def close; end
 end

--- a/lib/result_uploader.rb
+++ b/lib/result_uploader.rb
@@ -48,6 +48,12 @@ class ResultUploader
     @connected_uploaders.each_value(&:create_project_folder)
   end
 
+  def delete_file(r_name)
+    @connected_uploaders.each_value do |uploader|
+      uploader.delete_file(r_name)
+    end
+  end
+
   def upload_file(l_path, r_name)
     @connected_uploaders.each_value do |uploader|
       uploader.upload_file(l_path, r_name)


### PR DESCRIPTION
This series of commits, allows autohck to check for old test logs and delete them in case of faliure,
this is useful in case tests pass with filter and when tests are rerun.