### PR TITLE
Pre test commands based on device

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -6,6 +6,10 @@
     "inf": "netkvm.inf",
     "install_method": "PNP",
     "support": true,
+    "pretestcommands": [
+      { "desc": "Rename NetKVM ethernet adapter to SupportDevice0",
+        "run": "Rename-NetAdapter -Name (Get-NetAdapter -InterfaceDescription 'Red Hat VirtIO Ethernet Adapter').Name -NewName 'SupportDevice0'" }
+    ],
     "blacklist": [
       "NDISTest 6.0 - [2 Machine] - 2c_Mini6RSSSendRecv",
       "NDISTest 6.5 - [2 Machine] - MPE_Ethernet.xml",

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -118,6 +118,16 @@ class Client
     @tools.set_machine_ready(@name, @pool)
   end
 
+  def run_pre_test_commands
+    @project.device['pretestcommands']&.each do |command|
+      desc = command['desc']
+      cmd = command['run']
+
+      @logger.info("Running command (#{desc}) on client #{@name}")
+      @tools.run_on_machine(@name, desc, cmd)
+    end
+  end
+
   def install_driver
     method = @project.device['install_method']
     path = @project.driver_path
@@ -184,6 +194,7 @@ class Client
       install_driver
       @logger.info("Configuring client #{@name}...")
       configure_machine
+      run_pre_test_commands
       add_target_to_project
     end
   end


### PR DESCRIPTION
Some devices require some minor configurations pre testing, added
an optional 'pretestcommands' field to devices in devices.json, and
added the code to run them in order, if they exist.

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>