### PR TITLE
Github PR status update fixes

### DIFF
--- a/bin/auto_hck
+++ b/bin/auto_hck
@@ -41,6 +41,7 @@ Signal.trap('TERM') do
     Signal.trap('TERM') do
       @project.logger.warn('SIGTERM(*) received, ignoring...')
     end
+    @project&.handle_cancel
     clean_threads
     exit
   else
@@ -109,6 +110,7 @@ rescue StandardError => e
     @project.logger.warn('SIGTERM(*) received, ignoring...')
   end
   @project&.log_exception(e, 'fatal')
+  @project&.handle_error
   clean_threads
   raise e
 end

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -86,6 +86,13 @@ class Github
     create_status(state, description)
   end
 
+  def handle_cancel
+    @logger.info('Updating github status regarding cancel')
+    state = 'error'
+    description = 'HCK-CI run was canceled'
+    create_status(state, description)
+  end
+
   def handle_error
     @logger.info('Updating github status regarding error')
     state = 'error'

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -177,8 +177,15 @@ class Project
     @virthck.close
   end
 
+  def handle_cancel
+    @github.handle_cancel if @github&.connected?
+  end
+
+  def handle_error
+    @github.handle_error if @github&.connected?
+  end
+
   def abort
     @logger.remove_logger(@stdout_logger)
-    @github.handle_error if @github&.connected?
   end
 end


### PR DESCRIPTION
 1. Fixed where no matter what was the outcome of HCK-CI run, PR
    status will be updated to error in the end.
 2. Added a cancel HCK-CI run scenario with its corresponding PR
    status update.

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>