### PR TITLE
Added pre-test commands to fix disk settings for vioscsi and viostor

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -27,6 +27,12 @@
     "inf": "viostor.inf",
     "install_method": "PNP",
     "support": false,
+    "pretestcommands": [
+      { "desc": "Set Disk Operational Status to Online",
+        "run": "Set-Disk -Number 1 -IsOffline $False" },
+      { "desc": "Make Disk Writable",
+        "run": "Set-Disk -Number 1 -IsReadonly $False" }
+    ],
     "blacklist": [
       "Static Tools Logo Test",
       "Flush Test",
@@ -73,6 +79,12 @@
     "inf": "vioscsi.inf",
     "install_method": "PNP",
     "support": false,
+    "pretestcommands": [
+      { "desc": "Set Disk Operational Status to Online",
+        "run": "Set-Disk -Number 1 -IsOffline $False" },
+      { "desc": "Make Disk Writable",
+        "run": "Set-Disk -Number 1 -IsReadonly $False" }
+    ],
     "blacklist": [
       "Static Tools Logo Test",
       "Flush Test",


### PR DESCRIPTION
This commit fixes an issue where some tests failed vioscsi and viostor,
where the test disk status was offline and the disk was set to be read-only.

Signed-off-by: Basil Salman <basil@daynix.com>