### PR TITLE
Initial implementation of image creation

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
     "studio_username": "Administrator",
     "studio_password": "Qum5net.",
     "result_uploaders": [ "dropbox" ],
-    "engine": "hcktest",
+    "test_engine": "hcktest",
+    "install_engine": "hckinstall",
     "setupmanager": "virthck",
     "time_out": "9"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "iso_path": "/home/hck-ci/HCK-CI/iso",
     "workspace_path": "/home/hck-ci/HCK-CI/workspace",
     "ip_segment": "192.168.0.",
     "id_range": [ 2, 90 ],

--- a/lib/auxiliary/host_helper.rb
+++ b/lib/auxiliary/host_helper.rb
@@ -33,5 +33,13 @@ module AutoHCK
         end
       end
     end
+
+    def file_gsub(src, dst, gsub_list)
+      content = File.read(src)
+      gsub_list.each do |k, v|
+        content = content.gsub(k, v)
+      end
+      File.write(dst, content)
+    end
   end
 end

--- a/lib/auxiliary/iso_helper.rb
+++ b/lib/auxiliary/iso_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require './lib/auxiliary/host_helper'
+
+# AutoHCK module
+module AutoHCK
+  # Helper module
+  module Helper
+    def create_iso(iso_path, dir_paths)
+      run_cmd(['mkisofs', '-iso-level', '4', '-l', '-R', '-udf', '-D',
+               '-o', iso_path] + dir_paths)
+    end
+  end
+end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -9,13 +9,14 @@ module AutoHCK
   class CLI
     # class ScriptOptions
     class ScriptOptions
-      attr_accessor :tag, :path, :diff, :commit, :debug
+      attr_accessor :tag, :path, :diff, :commit, :debug, :install
 
       def define_options(parser)
         self.debug = false
         parser.banner = 'Usage: auto_hck.rb [options]'
         parser.separator ''
-        mandatory_options(parser)
+        mandatory_run_options(parser)
+        mandatory_install_options(parser)
         optional_options(parser)
         parser.on_tail('-h', '--help', 'Show this message') do
           puts parser
@@ -23,10 +24,15 @@ module AutoHCK
         end
       end
 
-      def mandatory_options(parser)
-        parser.separator 'Mandatory:'
+      def mandatory_run_options(parser)
+        parser.separator 'Mandatory for run:'
         tag_option(parser)
         path_option(parser)
+      end
+
+      def mandatory_install_options(parser)
+        parser.separator 'Mandatory for install:'
+        install_option(parser)
       end
 
       def optional_options(parser)
@@ -41,6 +47,13 @@ module AutoHCK
         parser.on('-c', '--commit <COMMITHASH>',
                   'Commit hash for CI status update') do |commit|
           self.commit = commit
+        end
+      end
+
+      def install_option(parser)
+        parser.on('-i', '--install <PLATFORM>',
+                  'Install VM for specified platform') do |install|
+          self.install = install
         end
       end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -9,7 +9,7 @@ module AutoHCK
   class CLI
     # class ScriptOptions
     class ScriptOptions
-      attr_accessor :tag, :path, :diff, :commit, :debug, :install
+      attr_accessor :tag, :path, :diff, :commit, :debug, :install, :force_install
 
       def define_options(parser)
         self.debug = false
@@ -40,6 +40,7 @@ module AutoHCK
         commit_option(parser)
         diff_option(parser)
         debug_option(parser)
+        force_install_option(parser)
         version_option(parser)
       end
 
@@ -85,6 +86,13 @@ module AutoHCK
         parser.on('-D', '--debug',
                   'Printing debug information') do |debug|
           self.debug = debug
+        end
+      end
+
+      def force_install_option(parser)
+        parser.on('--force-install',
+                  'Install all VM, replace studio if exist') do |force_install|
+          self.force_install = force_install
         end
       end
 

--- a/lib/engines/engine.rb
+++ b/lib/engines/engine.rb
@@ -50,6 +50,10 @@ module AutoHCK
       @engine.driver
     end
 
+    def platform
+      @engine.platform
+    end
+
     def close
       @engine.close
     end

--- a/lib/engines/engine.rb
+++ b/lib/engines/engine.rb
@@ -3,6 +3,7 @@
 require './lib/engines/exceptions'
 require './lib/setupmanagers/setupmanager'
 require './lib/engines/hcktest/hcktest'
+require './lib/engines/hckinstall/hckinstall'
 
 # AutoHCK module
 module AutoHCK
@@ -13,7 +14,8 @@ module AutoHCK
     #
     class EngineFactory
       ENGINES = {
-        hcktest: HCKTest
+        hcktest: HCKTest,
+        hckinstall: HCKInstall
       }.freeze
 
       def self.create(type, project)

--- a/lib/engines/engine.rb
+++ b/lib/engines/engine.rb
@@ -29,7 +29,7 @@ module AutoHCK
       @project = project
       @logger = project.logger
       @engine = nil
-      @type = project.config['engine'].downcase.to_sym
+      @type = project.engine_type.downcase.to_sym
       engine_create
     end
 

--- a/lib/engines/hckinstall/hckinstall.json
+++ b/lib/engines/hckinstall/hckinstall.json
@@ -1,0 +1,9 @@
+{
+  "hck_setup_scripts_path": "/home/hck-ci/HLK-Setup-Scripts",
+  "answer_files": [
+    "autounattend.xml",
+    "unattend.xml"
+  ],
+  "studio_install_timeout": 10800,
+  "client_install_timeout": 3600
+}

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+require './lib/auxiliary/json_helper'
+require './lib/auxiliary/host_helper'
+require './lib/auxiliary/iso_helper'
+require './lib/engines/hckinstall/setup_scripts_helper'
+
+# AutoHCK module
+module AutoHCK
+  # HCKInstall class
+  class HCKInstall
+    include Helper
+
+    attr_reader :platform
+
+    def initialize(project)
+      @project = project
+      @logger = project.logger
+      @project.append_multilog("#{project.install_platform}.log")
+      @logger.debug('HCKInstall: initialized')
+    end
+
+    def driver
+      nil
+    end
+
+    def run
+      @logger.debug('HCKInstall: run')
+    end
+
+    def close
+      @logger.debug('HCKInstall: close')
+    end
+  end
+end

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -15,23 +15,213 @@ module AutoHCK
 
     attr_reader :platform
 
+    PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
+    CONFIG_JSON = 'lib/engines/hckinstall/hckinstall.json'
+    ISO_JSON = 'lib/engines/hckinstall/iso.json'
+
     def initialize(project)
       @project = project
       @logger = project.logger
       @project.append_multilog("#{project.install_platform}.log")
+      init_workspace
+      init_config
+      init_class_variables
       @logger.debug('HCKInstall: initialized')
+    end
+
+    def init_workspace
+      @workspace_path = [@project.workspace_path, @project.install_platform,
+                         @project.timestamp].join('/')
+      begin
+        FileUtils.mkdir_p(@workspace_path)
+      rescue Errno::EEXIST
+        @project.logger.warn('Workspace path already exists')
+      end
+      @project.move_workspace_to(@workspace_path.to_s)
+    end
+
+    def read_platform
+      platforms = read_json(PLATFORMS_JSON, @logger)
+      platform_name = @project.install_platform
+      @logger.info("Loading platform: #{platform_name}")
+      res = platforms.find { |p| p['name'] == platform_name }
+      @logger.fatal("#{platform_name} does not exist") unless res
+      res || raise(InvalidConfigFile, "#{platform_name} does not exist")
+    end
+
+    def read_iso(platform_name)
+      iso = read_json(ISO_JSON, @logger)
+      @logger.info("Loading ISO for platform: #{platform_name}")
+      res = iso.find { |p| p['platform_name'] == platform_name }
+      @logger.fatal("ISO info for #{platform_name} does not exist") unless res
+      res || raise(InvalidConfigFile, "ISO info for #{platform_name} does not exist")
+    end
+
+    def init_config
+      @config = read_json(CONFIG_JSON, @logger)
+
+      @hck_setup_scripts_path = @config['hck_setup_scripts_path']
+
+      @answer_files = @config['answer_files']
+      @studio_install_timeout = @config['studio_install_timeout']
+      @client_install_timeout = @config['client_install_timeout']
+    end
+
+    def init_class_variables
+      @iso_path = @project.config['iso_path']
+
+      @platform = read_platform
+      @clients_name = @platform['clients'].keys
+
+      @iso_info = read_iso(@platform['name'])
+      validate_paths
+
+      @setup_studio_iso = "#{@workspace_path}/setup-studio.iso"
+      @setup_client_iso = "#{@workspace_path}/setup-client.iso"
+    end
+
+    def validate_paths
+      normalize_paths
+      return if File.exist?("#{@iso_path}/#{@iso_info['path']}")
+
+      @logger.fatal('ISO path is not valid')
+      exit(1)
+    end
+
+    def normalize_paths
+      @iso_info['path'].chomp!('/')
     end
 
     def driver
       nil
     end
 
+    def run_studio(snapshot = true)
+      st_opts = {
+        studio_snapshot: snapshot,
+        studio_iso_list: [
+          @setup_studio_iso,
+          @iso_info['path']
+        ]
+      }
+
+      st = Machine.new(@project, 'st', @project.setup_manager, 0, 'st')
+      st.run(st_opts)
+      st
+    end
+
+    def run_client(name, snapshot = true)
+      cl_opts = {
+        clients_snapshot: snapshot,
+        clients_iso_list: [
+          @setup_client_iso,
+          @iso_info['path']
+        ]
+      }
+
+      cl = Machine.new(@project, name, @project.setup_manager, name[/\d+/], name)
+      cl.run(cl_opts)
+      cl
+    end
+
+    def install_studio
+      @project.setup_manager.create_studio_image
+
+      @st = run_studio(false)
+
+      Timeout.timeout(@studio_install_timeout) do
+        @logger.info("Waiting for #{@st.name} #{@st.id} instalation finished")
+        sleep 5 while @st.alive?
+      end
+    end
+
+    def install_client(name)
+      @project.setup_manager.create_client_image(name)
+
+      run_client(name, false)
+    end
+
+    def install_clients
+      @project.setup_manager.create_studio_snapshot
+      @st = run_studio
+
+      @cl = @clients_name.map { |c| install_client(c) }
+
+      @cl.each do |client|
+        Timeout.timeout(@client_install_timeout) do
+          @logger.info("Waiting for #{client.name} #{client.id} instalation finished")
+          sleep 5 while client.alive?
+        end
+      end
+    end
+
+    def prepare_setup_scripts_config
+      kit_string = @platform['kit']
+      kit_type = kit_string[0..2]
+      kit_version = 0
+      kit_type == 'HCK' || kit_version = Integer(kit_string[/\d+/])
+
+      config = {
+        kit_type: kit_type,
+        hlk_kit_ver: kit_version
+      }
+      create_setup_scripts_config(@hck_setup_scripts_path, config)
+    end
+
+    def prepare_studio_iso
+      replacement_list = {
+        '@WINDOWS_IMAGE_NAME@' => @iso_info['windows_image_names'],
+        '@PRODUCT_KEY@' => @iso_info['product_key'],
+        '@HOST_TYPE@' => 'studio'
+      }
+      @answer_files.each do |file|
+        file_gsub(@hck_setup_scripts_path + "/answer-files/#{file}.in",
+                  @hck_setup_scripts_path + "/#{file}", replacement_list)
+      end
+      create_iso(@setup_studio_iso, [@hck_setup_scripts_path])
+    end
+
+    def prepare_client_iso
+      replacement_list = {
+        '@WINDOWS_IMAGE_NAME@' => @iso_info['windows_image_names'],
+        '@PRODUCT_KEY@' => @iso_info['product_key'],
+        '@HOST_TYPE@' => 'client'
+      }
+      @answer_files.each do |file|
+        file_gsub(@hck_setup_scripts_path + "/answer-files/#{file}.in",
+                  @hck_setup_scripts_path + "/#{file}", replacement_list)
+      end
+      create_iso(@setup_client_iso, [@hck_setup_scripts_path])
+    end
+
     def run
       @logger.debug('HCKInstall: run')
+
+      prepare_setup_scripts_config
+      prepare_studio_iso
+      prepare_client_iso
+
+      install_studio
+      install_clients
+    end
+
+    def cleanup_studio
+      @st&.abort
+      @project&.setup_manager&.delete_studio_snapshot
+    end
+
+    def cleanup_clients
+      @cl&.map(&:abort)
+      @clients_name.each do |client|
+        @project&.setup_manager&.delete_client_snapshot(client)
+      end
     end
 
     def close
       @logger.debug('HCKInstall: close')
+
+      cleanup_studio
+      cleanup_clients
     end
   end
 end

--- a/lib/engines/hckinstall/iso.json
+++ b/lib/engines/hckinstall/iso.json
@@ -1,0 +1,8 @@
+[
+  {
+    "platform_name": "Win2019x64",
+    "path": "en_windows_server_2019_updated_oct_2020_x64_dvd_7484fc77.iso",
+    "windows_image_names": "Windows Server 2019 SERVERSTANDARD",
+    "product_key": "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
+  }
+]

--- a/lib/engines/hckinstall/setup_scripts_helper.rb
+++ b/lib/engines/hckinstall/setup_scripts_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require './lib/exceptions'
+
+# AutoHCK module
+module AutoHCK
+  # Helper module
+  module Helper
+    SUPPORTED_CONFIG = {
+      kit_type: '',
+      hlk_kit_ver: '',
+      remove_gui: '',
+      debug: ''
+    }.freeze
+
+    def validate_setup_scripts_config(config)
+      (config.keys - SUPPORTED_CONFIG.keys).each do |cfg|
+        raise(AutoHCKError, "Undefined HLK setup scripts config #{cfg.inspect}")
+      end
+    end
+
+    def create_setup_scripts_config(hck_setup_scripts_path, config)
+      validate_setup_scripts_config(config)
+
+      args_file = File.open("#{hck_setup_scripts_path}/args.ps1", 'w')
+      config.each do |k, v|
+        key = k.to_s.upcase.gsub(/[^0-9a-z]/i, '')
+        case v
+        when true, false
+          value = "$#{v}"
+        when String
+          value = "'#{v}'"
+        when Integer
+          value = v
+        else
+          @logger.fatal("Unexpected value #{x} for config")
+          raise(AutoHCKError, "Unexpected value #{x} for config")
+        end
+
+        args_file.write("$#{key} = #{value}\n")
+      end
+      args_file.close
+    end
+  end
+end

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -10,7 +10,7 @@ module AutoHCK
   # HCKTest class
   class HCKTest
     include Helper
-    attr_reader :driver
+    attr_reader :driver, :platform
 
     PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
     DRIVERS_JSON = 'drivers.json'

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -19,7 +19,8 @@ module AutoHCK
     include Helper
 
     attr_reader :config, :logger, :timestamp, :setup_manager, :engine, :tag, :id,
-                :driver, :driver_path, :workspace_path, :github, :result_uploader
+                :driver, :driver_path, :workspace_path, :github, :result_uploader,
+                :install_platform, :engine_type
 
     DRIVERS_JSON = './drivers.json'
     CONFIG_JSON = 'config.json'
@@ -31,6 +32,7 @@ module AutoHCK
       github_handling(options.commit)
       init_workspace
       @id = assign_id
+      @install_platform = options.install
     end
 
     def diff_checker(driver, diff)
@@ -99,6 +101,7 @@ module AutoHCK
       @tag = options.tag
       @driver_path = options.path
       @diff = options.diff
+      @engine_type = options.install.nil? ? @config['test_engine'] : @config['install_engine']
     end
 
     def assign_id
@@ -142,7 +145,7 @@ module AutoHCK
     end
 
     def init_workspace
-      @workspace_path = [@config['workspace_path'], @config['engine'],
+      @workspace_path = [@config['workspace_path'], @engine_type,
                          @config['setupmanager']].join('/')
       begin
         FileUtils.mkdir_p(@workspace_path)

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -20,19 +20,19 @@ module AutoHCK
 
     attr_reader :config, :logger, :timestamp, :setup_manager, :engine, :tag, :id,
                 :driver, :driver_path, :workspace_path, :github, :result_uploader,
-                :install_platform, :engine_type
+                :install_platform, :engine_type, :options
 
     DRIVERS_JSON = './drivers.json'
     CONFIG_JSON = 'config.json'
 
     def initialize(options)
+      @options = options
       init_multilog(options.debug)
-      init_class_variables(options)
+      init_class_variables
       configure_result_uploader
       github_handling(options.commit)
       init_workspace
       @id = assign_id
-      @install_platform = options.install
     end
 
     def diff_checker(driver, diff)
@@ -95,13 +95,14 @@ module AutoHCK
       @workspace_path = path
     end
 
-    def init_class_variables(options)
+    def init_class_variables
       @config = read_json(CONFIG_JSON, @logger)
       @timestamp = create_timestamp
-      @tag = options.tag
-      @driver_path = options.path
-      @diff = options.diff
-      @engine_type = options.install.nil? ? @config['test_engine'] : @config['install_engine']
+      @tag = @options.tag
+      @driver_path = @options.path
+      @diff = @options.diff
+      @install_platform = @options.install
+      @engine_type = @options.install.nil? ? @config['test_engine'] : @config['install_engine']
     end
 
     def assign_id

--- a/lib/setupmanagers/machine.rb
+++ b/lib/setupmanagers/machine.rb
@@ -8,7 +8,7 @@ require './lib/setupmanagers/monitor'
 module AutoHCK
   # Machine class
   class Machine
-    attr_reader :name
+    attr_reader :name, :id
 
     def initialize(project, name, setupmanager, id, tag)
       @name = name

--- a/lib/setupmanagers/machine.rb
+++ b/lib/setupmanagers/machine.rb
@@ -19,9 +19,9 @@ module AutoHCK
       @id = id
     end
 
-    def run
+    def run(run_opts = { first_time: true })
       @logger.info("Starting #{@name}")
-      @pid = @setupmanager.run(@tag, { first_time: true })
+      @pid = @setupmanager.run(@tag, run_opts)
       raise MachinePidNil, "#{@name} PID could not be retrieved" unless @pid
 
       return if @pid.negative?

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -17,7 +17,7 @@ module AutoHCK
     def initialize(project)
       @project = project
       @logger = project.logger
-      @platform = read_platform
+      @platform = project.engine.platform
       @setup = find_setup
       @id = project.id
       @kit = @setup['kit']
@@ -28,14 +28,6 @@ module AutoHCK
       res = known_setups.find { |setup| setup['name'] == @platform['name'] }
       @project.logger.fatal("#{@platform['name']} does not exist") unless res
       res || raise(SetupManagerError, "#{@platform['name']} does not exist")
-    end
-
-    def read_platform
-      platforms = read_json(PLATFORMS_JSON, @project.logger)
-      platform_name = @project.tag.split('-', 2).last
-      res = platforms.find { |p| p['name'] == platform_name }
-      @project.logger.fatal("#{platform_name} does not exist") unless res
-      res || raise(SetupManagerError, "#{platform_name} does not exist")
     end
 
     def create_studio_image

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -30,6 +30,10 @@ module AutoHCK
       res || raise(SetupManagerError, "#{@platform['name']} does not exist")
     end
 
+    def check_studio_image_exist
+      @logger.info('Image checking is currently not supported for physical machines')
+    end
+
     def create_studio_image
       @logger.info('Image creating is currently not supported for physical machines')
     end
@@ -40,6 +44,10 @@ module AutoHCK
 
     def delete_studio_snapshot
       @logger.info('Snapshots are currently not supported for physical machines')
+    end
+
+    def check_client_image_exist(_name)
+      @logger.info('Image checking is currently not supported for physical machines')
     end
 
     def create_client_image(_name)

--- a/lib/setupmanagers/setupmanager.rb
+++ b/lib/setupmanagers/setupmanager.rb
@@ -44,6 +44,10 @@ module AutoHCK
       end
     end
 
+    def check_studio_image_exist
+      @setupmanager.check_studio_image_exist
+    end
+
     def create_studio_image
       @setupmanager.create_studio_image
     end
@@ -54,6 +58,10 @@ module AutoHCK
 
     def delete_studio_snapshot
       @setupmanager.delete_studio_snapshot
+    end
+
+    def check_client_image_exist(name)
+      @setupmanager.check_client_image_exist(name)
     end
 
     def create_client_image(name)

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -239,15 +239,24 @@ module AutoHCK
       @config['virthck_path'].chomp!('/')
     end
 
+    def check_studio_image_exist
+      File.exist?("#{@config['images_path']}/#{@platform['st_image']}")
+    end
+
+    def check_client_image_exist(name)
+      client = @platform['clients'][name]
+      File.exist?("#{@config['images_path']}/#{client['image']}")
+    end
+
     def validate_images(name)
       if name == STUDIO
-        unless File.exist?("#{@config['images_path']}/#{@platform['st_image']}")
+        unless check_studio_image_exist
           @logger.fatal('Studio image not found')
           raise InvalidPathError
         end
       else
         client = @platform['clients'][name]
-        unless File.exist?("#{@config['images_path']}/#{client['image']}")
+        unless check_client_image_exist(name)
           @logger.fatal("#{client['name']} image not found")
           raise InvalidPathError
         end

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -98,7 +98,8 @@ module AutoHCK
       drive_cmd = []
 
       @run_options[:studio_iso_list].each do |iso|
-        drive_cmd += ["-drive file=#{@project.config['iso_path']}/#{iso},media=cdrom,readonly=on"]
+        iso_path = Pathname.new(@project.config['iso_path']).join(iso)
+        drive_cmd += ["-drive file=#{iso_path},media=cdrom,readonly=on"]
       end
 
       drive_cmd.empty? ? [] : ['-st_extra', "'#{drive_cmd.join(' ')}'"]
@@ -108,7 +109,8 @@ module AutoHCK
       drive_cmd = []
 
       @run_options[:clients_iso_list].each do |iso|
-        drive_cmd += ["-drive file=#{@project.config['iso_path']}/#{iso},media=cdrom,readonly=on"]
+        iso_path = Pathname.new(@project.config['iso_path']).join(iso)
+        drive_cmd += ["-drive file=#{iso_path},media=cdrom,readonly=on"]
       end
 
       drive_cmd.empty? ? [] : ["-#{name}_extra", "'#{drive_cmd.join(' ')}'"]

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -33,6 +33,7 @@ module AutoHCK
       @workspace_path = project.workspace_path
       @id = project.id
       @kit = @platform['kit']
+      @run_options = DEFAULT_RUN_OPTIONS
     end
 
     def read_platform

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -29,20 +29,11 @@ module AutoHCK
       @logger = project.logger
       @config = read_json(VIRTHCK_CONFIG_JSON, @logger)
       @device = project.engine.driver&.dig('device')
-      @platform = read_platform
+      @platform = project.engine.platform
       @workspace_path = project.workspace_path
       @id = project.id
       @kit = @platform['kit']
       @run_options = DEFAULT_RUN_OPTIONS
-    end
-
-    def read_platform
-      platforms = read_json(PLATFORMS_JSON, @project.logger)
-      platform_name = @project.tag.split('-', 2).last
-      @project.logger.info("Loading platform: #{platform_name}")
-      res = platforms.find { |p| p['name'] == platform_name }
-      @project.logger.fatal("#{platform_name} does not exist") unless res
-      res || raise(SetupManagerError, "#{platform_name} does not exist")
     end
 
     def studio_snapshot


### PR DESCRIPTION
The current implementation has a few limitations, that will be fixed in the next PR
- ~~install engine installs all images (studio and 2 clients), existing studio image will be used unless - **--force option is added**~~
- studio and client VMs will be installed from the one Windows ISO - **client platform will be parsed from filename**
- the corresponding version of HCK/HLK should be downloaded manually - **automatic download will be implemented**
- the corresponding windows ISO should be downloaded manually - **automatic download will be implemented**