### PR TITLE
project: Configure GitHub status after diff_checker

### DIFF
--- a/lib/project.rb
+++ b/lib/project.rb
@@ -30,7 +30,6 @@ module AutoHCK
       init_multilog(options.debug)
       init_class_variables
       configure_result_uploader
-      github_handling(options.commit)
       init_workspace
       @id = assign_id
     end
@@ -46,6 +45,8 @@ module AutoHCK
     def prepare
       @engine = Engine.new(self)
       @engine.driver.nil? || diff_checker(@engine.driver, @diff)
+
+      github_handling(@options.commit)
 
       @setup_manager = SetupManager.new(self)
     end


### PR DESCRIPTION
This is needed to prevent status adding for drivers that
will be not tested.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>

Fix wrong status at https://github.com/virtio-win/kvm-guest-drivers-windows/pull/563