### PR TITLE
kit.json: Install fix for HLK1809

### DIFF
--- a/lib/engines/hckinstall/kit.json
+++ b/lib/engines/hckinstall/kit.json
@@ -2,12 +2,12 @@
   {
     "kit": "HLK1809server",
     "download_url": "https://go.microsoft.com/fwlink/?linkid=2026646",
-    "extra_software": [ "FOD_2019", "HLK_GRFX_FOD", "winfsp" ]
+    "extra_software": [ "FOD_2019", "HLK_GRFX_FOD", "WDTFNetData_1809", "winfsp" ]
   },
   {
     "kit": "HLK1809",
     "download_url": "https://go.microsoft.com/fwlink/?linkid=2026646",
-    "extra_software": [ "HLK_GRFX_FOD", "winfsp" ]
+    "extra_software": [ "HLK_GRFX_FOD", "WDTFNetData_1809", "winfsp" ]
   },
   {
     "kit": "HLK2004",


### PR DESCRIPTION
HLK Studio for Windows Server 2019 and Windows 10 1809 contain
a bug with the PNP Surprise removal test. MS provided an updated
binary that should solve the failure.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>