### PR TITLE
Add /override.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ build-iPhoneSimulator/
 # AutoHCK database
 /id_gen.db
 /lib/resultuploaders/dropbox.token.json
-/override.json
+/override.*


### PR DESCRIPTION
AutoHCK-Installer can create `/override.old` and `/override.install.json`.

Signed-off-by: Akihiko Odaki <akihiko.odaki@daynix.com>