### PR TITLE
QemuHCK: Let studio manage network control bridge

### DIFF
--- a/lib/setupmanagers/qemuhck/network_manager.rb
+++ b/lib/setupmanagers/qemuhck/network_manager.rb
@@ -125,7 +125,11 @@ module AutoHCK
         cmd, replacement_list = device_info(type, device_name, options, qemu_replacement_list)
         create_net_up_script(replacement_list.merge({ '@bridge_name@' => @control_bridge }))
 
-        [cmd, create_bridge_commands(@control_bridge), remove_bridge_commands(@control_bridge)]
+        cmd
+      end
+
+      def control_bridge_command
+        [create_bridge_commands(@control_bridge), remove_bridge_commands(@control_bridge)]
       end
 
       def world_device_command(device_name, bridge_name, qemu_replacement_list = {})
@@ -142,7 +146,7 @@ module AutoHCK
         cmd, replacement_list = device_info(type, device_name, options, qemu_replacement_list)
         create_net_up_script(replacement_list.merge({ '@bridge_name@' => bridge_name }))
 
-        [cmd, nil, nil]
+        cmd
       end
 
       def test_device_command(device_name, qemu_replacement_list = {})
@@ -159,7 +163,11 @@ module AutoHCK
         cmd, replacement_list = device_info(type, device_name, options, qemu_replacement_list)
         create_net_up_script(replacement_list.merge({ '@bridge_name@' => @test_bridge }))
 
-        [cmd, create_bridge_commands(@test_bridge), remove_bridge_commands(@test_bridge)]
+        cmd
+      end
+
+      def test_bridge_command
+        [create_bridge_commands(@test_bridge), remove_bridge_commands(@test_bridge)]
       end
 
       def transfer_device_command(device_name, transfer_net, share_path, qemu_replacement_list = {})
@@ -177,7 +185,7 @@ module AutoHCK
 
         cmd, = device_info(type, device_name, options, qemu_replacement_list)
 
-        [cmd, nil, nil]
+        cmd
       end
 
       def close; end

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -278,10 +278,11 @@ module AutoHCK
     def process_device(device_info)
       case device_info['type']
       when 'network'
-        dev, run_start, run_stop = @nm.test_device_command(device_info['name'], full_replacement_list)
+        dev = @nm.test_device_command(device_info['name'], full_replacement_list)
+        bridge_start, bridge_stop = @nm.test_bridge_command
         @device_commands << dev
-        @nm_commands_start << run_start
-        @nm_commands_stop << run_stop
+        @nm_commands_start << bridge_start
+        @nm_commands_stop << bridge_stop
       else
         cmd = device_info['command_line'].join(' ')
         @device_commands << replace_string_recursive(cmd, full_replacement_list)
@@ -291,32 +292,30 @@ module AutoHCK
     def process_optional_hck_network
       return unless @config['transfer_net_enabled']
 
-      dev, run_start, run_stop = @nm.transfer_device_command(@config['transfer_net_device'],
-                                                             @config['share_on_host_net'],
-                                                             @config['share_on_host_path'],
-                                                             full_replacement_list)
+      dev = @nm.transfer_device_command(@config['transfer_net_device'],
+                                        @config['share_on_host_net'],
+                                        @config['share_on_host_path'],
+                                        full_replacement_list)
       @device_commands << dev
-      @nm_commands_start << run_start
-      @nm_commands_stop << run_stop
     end
 
     def process_world_hck_network
-      dev, run_start, run_stop = @nm.world_device_command(option_config('world_net_device'),
-                                                          @config['world_net_bridge'],
-                                                          full_replacement_list)
+      dev = @nm.world_device_command(option_config('world_net_device'),
+                                     @config['world_net_bridge'],
+                                     full_replacement_list)
       @device_commands << dev
-      @nm_commands_start << run_start
-      @nm_commands_stop << run_stop
     end
 
     def process_hck_network
-      dev, run_start, run_stop = @nm.control_device_command(option_config('ctrl_net_device'),
-                                                            full_replacement_list)
+      dev = @nm.control_device_command(option_config('ctrl_net_device'),
+                                       full_replacement_list)
       @device_commands << dev
-      @nm_commands_start << run_start
-      @nm_commands_stop << run_stop
 
       return unless @options['client_id'].zero?
+
+      bridge_start, bridge_stop = @nm.control_bridge_command
+      @nm_commands_start << bridge_start
+      @nm_commands_stop << bridge_stop
 
       @nm_commands_start << @nm.disable_bridge_nf
 

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -279,10 +279,7 @@ module AutoHCK
       case device_info['type']
       when 'network'
         dev = @nm.test_device_command(device_info['name'], full_replacement_list)
-        bridge_start, bridge_stop = @nm.test_bridge_command
         @device_commands << dev
-        @nm_commands_start << bridge_start
-        @nm_commands_stop << bridge_stop
       else
         cmd = device_info['command_line'].join(' ')
         @device_commands << replace_string_recursive(cmd, full_replacement_list)
@@ -314,6 +311,10 @@ module AutoHCK
       return unless @options['client_id'].zero?
 
       bridge_start, bridge_stop = @nm.control_bridge_command
+      @nm_commands_start << bridge_start
+      @nm_commands_stop << bridge_stop
+
+      bridge_start, bridge_stop = @nm.test_bridge_command
       @nm_commands_start << bridge_start
       @nm_commands_stop << bridge_stop
 


### PR DESCRIPTION
Before this change, `QemuMachine` used to run the command to delete the network control bridge for each client. The later command executions was failing because the bridge was already removed with the earlier command and it did no longer exist.

With this change, the studio machine solely manages the network control bridge, and clients do no longer try to delete the network control bridge by its own. In fact, such a behavior was already present for the other network devices, and this change merely expands the scope of the behavior.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>