### PR TITLE
Handle trap in a seperate thread

### DIFF
--- a/lib/trap.rb
+++ b/lib/trap.rb
@@ -10,7 +10,7 @@ module AutoHCK
 
     def self.clean_threads
       Thread.list.each do |thread|
-        thread.exit unless Thread.main.eql?(thread)
+        thread.exit unless Thread.current.eql?(thread) && Thread.main.eql?(thread)
       end
     end
 
@@ -26,10 +26,12 @@ module AutoHCK
       Signal.trap(signal) do
         write_log("SIG#{signal}(*) received, ignoring...")
       end
-      @project&.handle_cancel
-      @project&.close
-      clean_threads
-      exit
+      Thread.start do
+        @project&.handle_cancel
+        @project&.close
+        clean_threads
+        exit
+      end
     end
 
     @sig_status = {}


### PR DESCRIPTION
https://docs.ruby-lang.org/en/3.1/signals_rdoc.html says `Mutex#synchronize` is unsafe in `Signal.trap` blocks. In fact, it raises `ThreadError` in the context. The method is called in the following chain:
1. `AutoHCK::Trap.perform_trap`
2. `AutoHCK::Project#close`
3. `AutoHCK::Engine#close`
4. `AutoHCK::HCKTest#close`
5. `AutoHCK::HCKStudio#abort`
6. `AutoHCK::Tools#close`
7. `AutoHCK::Tools::ThreadSafe#method_missing`

The documentation also says:
> Creating a new Thread via `Thread.new`/`Thread.start` can used to get around the unusability of Mutexes inside a signal handler

This change introduces `Thread.start` accordingly.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>