### PR TITLE
Ignore bridge netfilter sysctls if not exist

### DIFF
--- a/lib/setupmanagers/qemuhck/network_manager.rb
+++ b/lib/setupmanagers/qemuhck/network_manager.rb
@@ -58,9 +58,9 @@ module AutoHCK
 
       def disable_bridge_nf_commands
         [
-          'sysctl net.bridge.bridge-nf-call-arptables=0',
-          'sysctl net.bridge.bridge-nf-call-ip6tables=0',
-          'sysctl net.bridge.bridge-nf-call-iptables=0'
+          'sysctl -e net.bridge.bridge-nf-call-arptables=0',
+          'sysctl -e net.bridge.bridge-nf-call-ip6tables=0',
+          'sysctl -e net.bridge.bridge-nf-call-iptables=0'
         ]
       end
 


### PR DESCRIPTION
bridge netfilter sysctls do not exist if `br_netfilter` is not loaded. As the sysctls are only used to disable bridge netfilter, it is safe to ignore the sysctls if they do not exist.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>