### PR TITLE
Create own network namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.6.5-node-browsers
+      - image: cimg/ruby:2.7.6
 
     working_directory: ~/repo
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Setup libcurl-devel
       run: sudo apt-get -y install libcurl4 libcurl3-gnutls libcurl4-openssl-dev
 
-    - name: Set up Ruby 2.6.5
+    - name: Set up Ruby 2.7.6
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.5
+        ruby-version: 2.7.6
         bundler-cache: true
 
     - name: Install dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'mono_logger'
 gem 'net-ping'
 gem 'octokit'
 gem 'openssl', require: false
-gem 'rtoolsHCK', git: 'https://github.com/HCK-CI/rtoolsHCK.git', tag: 'v0.3.0'
+gem 'rtoolsHCK', git: 'https://github.com/HCK-CI/rtoolsHCK.git', tag: 'v0.3.1'
 gem 'rubyzip'
 gem 'sentry-ruby'
 gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '>= 2.6.5'
+ruby '>= 2.7.0'
 
 gem 'activesupport'
 gem 'curb'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'dotenv'
 gem 'dropbox_api'
 gem 'filelock'
 gem 'mono_logger'
-gem 'net-ping'
 gem 'octokit'
 gem 'openssl', require: false
 gem 'rtoolsHCK', git: 'https://github.com/HCK-CI/rtoolsHCK.git', tag: 'v0.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/HCK-CI/rtoolsHCK.git
-  revision: 4db7d7a74316bac9dc7ff0726783466f0193da79
-  tag: v0.3.0
+  revision: 6b4d576824f85e7fd21f9bcd50d470d6c7c12d41
+  tag: v0.3.1
   specs:
-    rtoolsHCK (0.3.0)
+    rtoolsHCK (0.3.1)
       bundler
       rdoc
       winrm (= 2.3.4)
@@ -31,7 +31,7 @@ GEM
     dropbox_api (0.1.20)
       faraday (~> 1.0)
       oauth2 (~> 1.1)
-    erubi (1.10.0)
+    erubi (1.11.0)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
@@ -49,7 +49,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jwt (2.2.3)
     little-plugger (1.1.4)
-    logging (2.3.0)
+    logging (2.3.1)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
     minitest (5.14.4)
@@ -72,7 +72,7 @@ GEM
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
-    psych (4.0.3)
+    psych (4.0.4)
       stringio
     public_suffix (4.0.6)
     rack (2.2.3.1)
@@ -122,7 +122,7 @@ GEM
       concurrent-ruby
       faraday
     sqlite3 (1.4.2)
-    stringio (3.0.1)
+    stringio (3.0.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,6 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    net-ping (2.0.8)
     nori (2.6.0)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -153,7 +152,6 @@ DEPENDENCIES
   dropbox_api
   filelock
   mono_logger
-  net-ping
   octokit
   openssl
   rspec

--- a/bin/ns
+++ b/bin/ns
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'English'
+require 'fileutils'
+require 'tmpdir'
+
+e_read, e_write = IO.pipe
+r_read, r_write = IO.pipe
+e_read.close_on_exec = false
+r_write.close_on_exec = false
+parent = Process.pid
+a_dir = Dir.mktmpdir('autohck')
+a = File.join(a_dir, 'sock')
+
+fork do
+  e_write.close
+  r_read.close
+  Process.setpgid 0, 0
+  e_read.read 1
+
+  slirp = spawn('slirp4netns', '-r', r_write.fileno.to_s,
+                '-a', a, parent.to_s, 'tap_host')
+  begin
+    r_write.close
+    e_read.read 1
+  ensure
+    Process.kill 9, slirp
+    Process.wait
+
+    warn "slirp4nents: unexpected exit status #{$CHILD_STATUS.exitstatus}" if $CHILD_STATUS.termsig != 9
+  end
+ensure
+  e_read.close
+  FileUtils.remove_entry_secure a_dir
+end
+
+e_read.close
+r_write.close
+e_write.close_on_exec = false
+r_read.close_on_exec = false
+
+ENV['AUTOHCK_SLIRP'] = a
+
+exec 'unshare', '--user', '--map-root-user', '--net', '--mount',
+     File.join(__dir__, 'ns_unshared'), e_write.fileno.to_s, r_read.fileno.to_s,
+     *(ARGV.empty? ? ['sh'] : ARGV)

--- a/bin/ns_unshared
+++ b/bin/ns_unshared
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'English'
+require 'fileutils'
+
+[
+  '/proc/sys/net/bridge/bridge-nf-call-arptables',
+  '/proc/sys/net/bridge/bridge-nf-call-ip6tables',
+  '/proc/sys/net/bridge/bridge-nf-call-iptables'
+].each do
+  File.write _1, '0'
+rescue Errno::ENOENT
+  # br_netfilter is not loaded
+end
+
+e_write = IO.new(ARGV[0].to_i)
+e_write.write '1'
+e_write.flush
+
+r_read = IO.new(ARGV[1].to_i)
+r = r_read.read(1)
+r_read.close
+
+return if r.nil?
+
+[
+  ['mount', '--bind', File.join(__dir__, '..', 'resolv.conf'), '/etc/resolv.conf'],
+  %w[ip link set tap_host up],
+  %w[ip link add br_world type bridge],
+  %w[ip addr add 10.0.2.100/24 dev br_world],
+  %w[ip link set tap_host master br_world],
+  %w[ip link set br_world up],
+  %w[ip route add default via 10.0.2.2],
+  %w[ip link add br_ctrl type bridge],
+  %w[ip link set br_ctrl up],
+  %w[ip link add br_test type bridge],
+  %w[ip link set br_test up]
+].each do
+  Process.wait spawn(*_1)
+  raise $CHILD_STATUS.to_s unless $CHILD_STATUS.success?
+rescue StandardError
+  raise "#{_1}: command failed"
+end
+
+exec(*ARGV[2..])

--- a/config.json
+++ b/config.json
@@ -2,7 +2,6 @@
     "iso_path": "/home/hck-ci/HCK-CI/iso",
     "extra_software": "/home/hck-ci/HCK-CI/extra-software",
     "workspace_path": "/home/hck-ci/HCK-CI/workspace",
-    "ip_segment": "192.168.0.",
     "id_range": [ 2, 90 ],
     "winrm_port": "5985",
     "repository": "virtio-win/kvm-guest-drivers-windows",

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -92,7 +92,7 @@ module AutoHCK
 
     def create_studio
       studio_ip = @setup['st_ip']
-      @studio = HCKStudio.new(@project, self, 'st', studio_ip)
+      @studio = HCKStudio.new(@project, self, 'st') { studio_ip }
     end
 
     def create_client(name)

--- a/lib/setupmanagers/qemuhck/qemu_machine.json
+++ b/lib/setupmanagers/qemuhck/qemu_machine.json
@@ -6,7 +6,6 @@
   "fs_daemon_share_path" : "/root/Prometheus/fs_share",
   "images_path": "/root/Prometheus/images",
   "fs_test_image": "/root/Prometheus/images/filesystem_tests_image.qcow2",
-  "world_net_bridge": "br0",
   "transfer_net_enabled": false,
   "transfer_net_device": "e1000e",
   "share_on_host_net__comment": "The =FIRST THREE= octets of the share IP",

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -376,6 +376,12 @@ module AutoHCK
       ].compact
     end
 
+    def read_world_ip
+      @nm.read_world_ip option_config('world_net_device'),
+                        @config['world_net_bridge'],
+                        full_replacement_list
+    end
+
     def dump_config
       config = [
         'Setup configuration:',

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -173,8 +173,7 @@ module AutoHCK
     end
 
     def create_studio
-      studio_ip = @project.config['ip_segment'] + @project.id.to_str
-      @studio = HCKStudio.new(@project, self, studio_ip)
+      @studio = HCKStudio.new(@project, self) { @studio_vm.read_world_ip }
     end
 
     def create_client(name)

--- a/lib/setupmanagers/qemuhck/slirp.rb
+++ b/lib/setupmanagers/qemuhck/slirp.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'socket'
+
+# AutoHCK module
+module AutoHCK
+  # Slirp class
+  class Slirp
+    def initialize(path)
+      @path = path
+    end
+
+    def run(request)
+      UNIXSocket.open @path do
+        _1.write JSON.dump(request)
+        _1.flush
+
+        response = JSON.parse(_1.read)
+        raise response['error'].to_s if response.key?('error')
+
+        response['return']
+      end
+    end
+  end
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,6 +3,6 @@
 # AutoHCK module
 module AutoHCK
   class AutoHCK
-    VERSION = '0.9.12'
+    VERSION = '0.10.0'
   end
 end

--- a/resolv.conf
+++ b/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 10.0.2.3


### PR DESCRIPTION
Although I said the command invocation will be `bin/ns bin/auto_hck` in an internal meeting, ~~I decided to make it work just by `bin/auto_hck`~~. `bin/ns` still exists for manual testing.

Don't forget to install slirp4netns before testing.