### PR TITLE
Remove some tests from the ignore list of igb

### DIFF
--- a/drivers.json
+++ b/drivers.json
@@ -41,10 +41,8 @@
       }
     ],
     "ignore_list": [
-      "NDISTest 6.5 - [2 Machine] - GlitchFreeDevice",
       "NDISTest 6.5 - [2 Machine] - VMQReceiveQueueStateChecking",
       "NDISTest 6.5 - [2 Machine] - VMQPowerManagement",
-      "NDISTest 6.0 - [1 Machine] - 1c_Mini6PerfSend",
       "Hardware-enforced Stack Protection Compatibility Test"
     ]
   },


### PR DESCRIPTION
It is confirmed that the tests are passing with the following QEMU version:
https://github.com/daynix/qemu/commit/5af17491d0326b8aa8fea93a81c35903ca0bf60c

It is probable that the tests are fine but the inaccuracy of QEMU's packet counters, which was fixed recently, affected them. Remove them from the ignore list.