### PR TITLE
Increase RAM memory for several platforms

### DIFF
--- a/lib/engines/hcktest/platforms/Win11_22H2x64_host_uefi_q35_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_22H2x64_host_uefi_q35_viommu.json
@@ -12,14 +12,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK11_22H2-C1-Win11_22H2x64-uefi-q35-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK11_22H2-C2-Win11_22H2x64-uefi-q35-viommu.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win11nextx64_host_uefi_q35_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11nextx64_host_uefi_q35_viommu.json
@@ -12,14 +12,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK11_22H2-C1-Win11nextx64-uefi-q35-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK11_22H2-C2-Win11nextx64-uefi-q35-viommu.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win2019x64.json
+++ b/lib/engines/hcktest/platforms/Win2019x64.json
@@ -6,14 +6,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "2G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK1809-C1-Win2019x64.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "2G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK1809-C2-Win2019x64.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win2019x64_uefi.json
+++ b/lib/engines/hcktest/platforms/Win2019x64_uefi.json
@@ -7,14 +7,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "2G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK1809-C1-Win2019x64-uefi.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "2G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK1809-C2-Win2019x64-uefi.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win2022nextx64_host_uefi_q35_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2022nextx64_host_uefi_q35_viommu.json
@@ -11,14 +11,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK2022-C1-Win2022nextx64-host-uefi-q35-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK2022-C2-Win2022nextx64-host-uefi-q35-viommu.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win2022x64.json
+++ b/lib/engines/hcktest/platforms/Win2022x64.json
@@ -6,14 +6,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK2022-C1-Win2022x64.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK2022-C2-Win2022x64.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win2022x64_host_uefi_q35_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_host_uefi_q35_viommu.json
@@ -11,14 +11,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK2022-C1-Win2022x64-uefi-q35-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK2022-C2-Win2022x64-uefi-q35-viommu.qcow2"
     }

--- a/lib/engines/hcktest/platforms/Win2022x64_uefi.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_uefi.json
@@ -7,14 +7,14 @@
     "c1": {
       "name": "CL1",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4002",
       "image": "HLK2022-C1-Win2022x64-uefi.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
-      "memory": "4G",
+      "memory": "8G",
       "winrm_port": "4003",
       "image": "HLK2022-C2-Win2022x64-uefi.qcow2"
     }


### PR DESCRIPTION
Microsoft recommends at least 1GB of RAM for 1 CPU. Several tests require more resources, so set 2GB of RAM for 1 CPU.

After a talk with Yuri, he recommends increasing RAM. We have enough resources for this on CI servers.