### PR TITLE
Introduce AutoHCK::ResourceScope

### DIFF
--- a/bin/auto_hck
+++ b/bin/auto_hck
@@ -7,6 +7,7 @@ require './lib/config/sentry'
 
 begin
   require 'filelock'
+  require './lib/auxiliary/resource_scope'
   require './lib/cli'
   require './lib/project'
   require './lib/trap'
@@ -25,8 +26,8 @@ begin
     Thread.abort_on_exception = true
     Thread.report_on_exception = false
 
-    @project = Project.new(cli)
-    begin
+    ResourceScope.open do |scope|
+      @project = Project.new(scope, cli)
       Trap.project = @project
       @project.run if @project.prepare
     rescue StandardError => e
@@ -37,9 +38,9 @@ begin
       @project.log_exception(e, 'fatal')
       @project.handle_error
       exit(1)
-    ensure
-      @project.close
     end
+  rescue AutoHCKInterrupt
+    exit false
   end
 rescue StandardError => e
   Sentry.capture_exception(e)

--- a/lib/auxiliary/id_gen.rb
+++ b/lib/auxiliary/id_gen.rb
@@ -7,11 +7,12 @@ require 'time'
 module AutoHCK
   # Id Generator class
   class Idgen
-    def initialize(range, timeout)
+    def initialize(scope, range, timeout)
       @db = './id_gen.db'
       @range = range
-      @conn = SQLite3::Database.new @db.to_s
       @threshold = timeout * 24 * 60 * 60
+      @conn = SQLite3::Database.new @db.to_s
+      scope << @conn
     end
 
     def load_data
@@ -55,8 +56,6 @@ module AutoHCK
       1
     rescue SQLite3::Exception
       -1
-    ensure
-      @conn&.close
     end
 
     private

--- a/lib/auxiliary/resource_scope.rb
+++ b/lib/auxiliary/resource_scope.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require './lib/exceptions'
+
+module AutoHCK
+  # ResourceScope is a class that manages objects with close methods.
+  class ResourceScope
+    def initialize(resources)
+      @resources = resources
+    end
+
+    def <<(resource)
+      @resources << resource
+      self
+    end
+
+    def transaction
+      resources = []
+      self.class.open(resources) do |scope|
+        result = yield(scope)
+        @resources.concat resources
+        resources.clear
+        result
+      end
+    end
+
+    def self.open(resources = [])
+      scope = new(resources)
+      Thread.handle_interrupt(AutoHCKInterrupt => :never) do
+        Thread.handle_interrupt(AutoHCKInterrupt => :on_blocking) do
+          yield scope
+        end
+      ensure
+        resources.reverse_each(&:close)
+      end
+    end
+  end
+end

--- a/lib/engines/config_manager/config_manager.rb
+++ b/lib/engines/config_manager/config_manager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require './lib/auxiliary/resource_scope'
 require './lib/resultuploaders/result_uploader'
 
 # AutoHCK module
@@ -34,9 +35,11 @@ module AutoHCK
     end
 
     def run
-      @project.logger.info('Stating result uploader token initialization')
-      @result_uploader = ResultUploader.new(@project)
-      @result_uploader.ask_token
+      ResourceScope.open do |scope|
+        @project.logger.info('Stating result uploader token initialization')
+        @result_uploader = ResultUploader.new(scope, @project)
+        @result_uploader.ask_token
+      end
     end
 
     def drivers
@@ -49,10 +52,6 @@ module AutoHCK
 
     def result_uploader_needed?
       false
-    end
-
-    def close
-      @project.logger.info('Closing helpers engine')
     end
   end
 end

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -202,10 +202,10 @@ module AutoHCK
         attach_iso_list: iso_list
       }
 
-      @project.setup_manager.run_hck_studio(scope, st_opts)
+      @project.setup_manager.run_studio(scope, st_opts)
     end
 
-    def run_client(scope, studio, name, snapshot: true)
+    def run_client(scope, name, snapshot: true)
       cl_opts = {
         create_snapshot: snapshot,
         attach_iso_list: [
@@ -214,7 +214,7 @@ module AutoHCK
         ]
       }
 
-      @project.setup_manager.run_hck_client(scope, studio, name, cl_opts)
+      @project.setup_manager.run_client(scope, name, cl_opts)
     end
 
     def run_studio_installer
@@ -232,19 +232,19 @@ module AutoHCK
       end
     end
 
-    def run_client_installer(scope, studio, name)
+    def run_client_installer(scope, name)
       @project.setup_manager.create_client_image(name)
 
-      run_client(scope, studio, name, snapshot: false)
+      run_client(scope, name, snapshot: false)
     end
 
     def run_clients_installer
       ResourceScope.open do |scope|
-        st = run_studio(scope, [], keep_alive: true)
-        cl = @clients_name.map { |c| run_client_installer(scope, st, c) }
+        run_studio(scope, [], keep_alive: true)
+        cl = @clients_name.map { |c| [c, run_client_installer(scope, c)] }
         Timeout.timeout(@client_install_timeout) do
-          cl.each do |client|
-            @logger.info("Waiting for #{client.name} installation finished")
+          cl.each do |name, client|
+            @logger.info("Waiting for #{name} installation finished")
             sleep 5 while client.alive?
           end
         end

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -200,9 +200,7 @@ module AutoHCK
         attach_iso_list: iso_list
       }
 
-      st = @project.setup_manager.create_studio
-      st.run(st_opts)
-      st
+      @project.setup_manager.run_hck_studio(st_opts)
     end
 
     def run_client(name, snapshot: true)
@@ -214,9 +212,7 @@ module AutoHCK
         ]
       }
 
-      cl = @project.setup_manager.create_client(name)
-      cl.run(cl_opts)
-      cl
+      @project.setup_manager.run_hck_client(name, cl_opts)
     end
 
     def run_studio_installer

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -225,10 +225,8 @@ module AutoHCK
                           @setup_studio_iso,
                           @studio_iso_info['path']
                         ], keep_alive: false, snapshot: false)
-        Timeout.timeout(@studio_install_timeout) do
-          @logger.info('Waiting for studio installation finished')
-          sleep 5 while st.alive?
-        end
+        @logger.info('Waiting for studio installation finished')
+        raise AutoHCKError, 'studio installation timed out' if st.wait(@studio_install_timeout).nil?
       end
     end
 
@@ -245,7 +243,7 @@ module AutoHCK
         Timeout.timeout(@client_install_timeout) do
           cl.each do |name, client|
             @logger.info("Waiting for #{name} installation finished")
-            sleep 5 while client.alive?
+            client.wait
           end
         end
       end

--- a/lib/engines/hckinstall/setup_scripts_helper.rb
+++ b/lib/engines/hckinstall/setup_scripts_helper.rb
@@ -41,24 +41,24 @@ module AutoHCK
     def create_setup_scripts_config(hck_setup_scripts_path, config)
       validate_setup_scripts_config(config)
 
-      args_file = File.open("#{hck_setup_scripts_path}/args.ps1", 'w')
-      config.each do |k, v|
-        key = k.to_s.upcase.gsub(/[^0-9a-z]/i, '')
-        case v
-        when true, false
-          value = "$#{v}"
-        when String
-          value = "'#{v}'"
-        when Integer
-          value = v
-        else
-          @logger.fatal("Unexpected value #{x} for config")
-          raise(AutoHCKError, "Unexpected value #{x} for config")
-        end
+      File.open("#{hck_setup_scripts_path}/args.ps1", 'w') do |args_file|
+        config.each do |k, v|
+          key = k.to_s.upcase.gsub(/[^0-9a-z]/i, '')
+          case v
+          when true, false
+            value = "$#{v}"
+          when String
+            value = "'#{v}'"
+          when Integer
+            value = v
+          else
+            @logger.fatal("Unexpected value #{x} for config")
+            raise(AutoHCKError, "Unexpected value #{x} for config")
+          end
 
-        args_file.write("$#{key} = #{value}\n")
+          args_file.write("$#{key} = #{value}\n")
+        end
       end
-      args_file.close
     end
   end
 end

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -199,7 +199,7 @@ module AutoHCK
 
       run_studio
       sleep 5 until @studio.up?
-      run_clients
+      run_clients keep_alive: true
 
       configure_setup_and_synchronize
     rescue AutoHCKError => e

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -344,11 +344,6 @@ module AutoHCK
       @support&.reset_to_ready_state
     end
 
-    def keep_clients_alive
-      @client.keep_alive
-      @support&.keep_alive
-    end
-
     def new_done
       list_tests
       done_tests - @last_done
@@ -369,7 +364,6 @@ module AutoHCK
 
     def handle_test_running(running = nil)
       until all_tests_finished?
-        keep_clients_alive
         reset_clients_to_ready_state
         check_new_finished_tests
         check_test_queued_time

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -5,6 +5,12 @@ module AutoHCK
   # A custom AutoHCK error exception
   class AutoHCKError < StandardError; end
 
+  # A custom AutoHCK interrupt exception that can be safely blocked with
+  # Thread.handle_interrupt without blocking the other exceptions.
+  # rubocop:disable Lint/InheritException
+  class AutoHCKInterrupt < Exception; end
+  # rubocop:enable Lint/InheritException
+
   # A custom GithubCommitInvalid error exception
   class GithubCommitInvalid < AutoHCKError; end
 

--- a/lib/resultuploaders/result_uploader.rb
+++ b/lib/resultuploaders/result_uploader.rb
@@ -34,7 +34,8 @@ module AutoHCK
       end
     end
 
-    def initialize(project)
+    def initialize(scope, project)
+      @scope = scope
       @project = project
       @connected_uploaders = {}
       @uploaders = {}
@@ -55,6 +56,7 @@ module AutoHCK
       @uploaders.each_pair do |type, uploader|
         if uploader.connect
           @connected_uploaders[type] = uploader
+          @scope << uploader
         else
           @project.logger.info("#{type} connection failed, (ignoring)")
         end
@@ -89,10 +91,6 @@ module AutoHCK
 
     def html_url
       @connected_uploaders.values.filter_map(&:html_url).first
-    end
-
-    def close
-      @connected_uploaders.each_value(&:close)
     end
   end
 end

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -189,7 +189,7 @@ module AutoHCK
     end
 
     def close
-      @logger.info("Aborting HLKClient #{@name}")
+      @logger.info("Exiting HLKClient #{@name}")
       @cooldown_thread&.exit
     end
   end

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -17,7 +17,7 @@ module AutoHCK
     attr_reader :name, :kit
     attr_writer :support
 
-    def initialize(project, setup_manager, studio, name)
+    def initialize(project, setup_manager, studio, name, run_opts)
       @project = project
       @logger = project.logger
       @studio = studio
@@ -25,9 +25,6 @@ module AutoHCK
       @kit = setup_manager.kit
       @setup_manager = setup_manager
       @pool = 'Default Pool'
-    end
-
-    def run(run_opts = nil)
       @setup_manager.run_client(@name, run_opts)
     end
 

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -32,10 +32,6 @@ module AutoHCK
       @setup_manager.client_alive?(@name)
     end
 
-    def keep_alive
-      @setup_manager.keep_client_alive(@name)
-    end
-
     def clean_last_run
       @setup_manager.clean_last_client_run(@name)
     end
@@ -142,19 +138,13 @@ module AutoHCK
 
     def recognize_client_wait
       @logger.info("Waiting for client #{@name} to be recognized")
-      until machine_in_default_pool
-        keep_alive
-        sleep 5
-      end
+      sleep 5 until machine_in_default_pool
       @logger.info("Client #{@name} recognized")
     end
 
     def initialize_client_wait
       @logger.info("Waiting for client #{@name} initialization")
-      while machine_in_default_pool['state'].eql?('Initializing')
-        keep_alive
-        sleep 5
-      end
+      sleep 5 while machine_in_default_pool['state'].eql?('Initializing')
       @logger.info("Client #{@name} initialized")
     end
 

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -28,7 +28,7 @@ module AutoHCK
     end
 
     def run(run_opts = nil)
-      @setup_manager.run(@name, run_opts)
+      @setup_manager.run_client(@name, run_opts)
     end
 
     def alive?

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -24,6 +24,7 @@ module AutoHCK
       @name = name
       @kit = setup_manager.kit
       @pool = 'Default Pool'
+      @logger.info("Starting client #{name}")
       @runner = setup_manager.run_client(scope, @name, run_opts)
       scope << self
     end

--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -8,7 +8,6 @@ module AutoHCK
   class HCKStudio
     attr_reader :tools
 
-    STUDIO = 'st'
     CONNECT_RETRIES = 5
     CONNECT_RETRY_SLEEP = 10
 
@@ -81,7 +80,7 @@ module AutoHCK
     end
 
     def run(run_opts = nil)
-      @setup_manager.run(STUDIO, run_opts)
+      @setup_manager.run_studio(run_opts)
     end
 
     def alive?

--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -11,12 +11,13 @@ module AutoHCK
     CONNECT_RETRIES = 5
     CONNECT_RETRY_SLEEP = 10
 
-    def initialize(project, setup_manager, &ip_getter)
+    def initialize(project, setup_manager, run_opts, &ip_getter)
       @project = project
       @tag = project.engine.tag
       @setup_manager = setup_manager
       @ip_getter = ip_getter
       @logger = project.logger
+      @setup_manager.run_studio(run_opts)
     end
 
     def up?
@@ -77,10 +78,6 @@ module AutoHCK
       return if @tools.connection_check
 
       raise StudioConnectError, 'Tools did not pass the connection check'
-    end
-
-    def run(run_opts = nil)
-      @setup_manager.run_studio(run_opts)
     end
 
     def alive?

--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -17,6 +17,7 @@ module AutoHCK
       @ip_getter = ip_getter
       @logger = @project.logger
       @scope = scope
+      @logger.info('Starting studio')
       @runner = setup_manager.run_studio(scope, run_opts)
     end
 

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -76,7 +76,7 @@ module AutoHCK
 
     def create_studio
       studio_ip = @setup['st_ip']
-      @studio = HCKStudio.new(@project, self, 'st') { studio_ip }
+      @studio = HCKStudio.new(@project, self) { studio_ip }
     end
 
     def create_client(name)

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -72,13 +72,13 @@ module AutoHCK
       @logger.info('Clean last run is currently not supported for physical machines')
     end
 
-    def create_studio
+    def run_hck_studio(run_opts)
       studio_ip = @setup['st_ip']
-      @studio = HCKStudio.new(@project, self) { studio_ip }
+      @studio = HCKStudio.new(@project, self, run_opts) { studio_ip }
     end
 
-    def create_client(name)
-      HCKClient.new(@project, self, @studio, name)
+    def run_hck_client(name, run_opts)
+      HCKClient.new(@project, self, @studio, name, run_opts)
     end
 
     def abort_studio

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -45,10 +45,8 @@ module AutoHCK
       @logger.info('Image creating is currently not supported for physical machines')
     end
 
-    def run(*)
-      # Physical = no pid
-      -1
-    end
+    def run_studio(*); end
+    def run_client(*); end
 
     def studio_alive?
       @logger.info('Physical machine is always alive')

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -7,9 +7,28 @@ require './lib/auxiliary/json_helper'
 module AutoHCK
   # PhysHCK
   class PhysHCK
+    # Runner is a class that represents a run.
+    class Runner
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def alive?
+        @logger.info('Physical machine is always alive')
+      end
+
+      def keep_snapshot
+        @logger.info('Keeping snapshot is currently not supported for physical machines')
+      end
+
+      def close
+        @logger.info('Abort is currently not supported for physical machines')
+      end
+    end
+
     include Helper
 
-    attr_reader :kit
+    attr_reader :kit, :project
 
     PHYSHCK_CONFIG_JSON = 'lib/setupmanagers/physhck/physhck.json'
 
@@ -45,52 +64,21 @@ module AutoHCK
       @logger.info('Image creating is currently not supported for physical machines')
     end
 
-    def run_studio(*); end
-    def run_client(*); end
-
-    def studio_alive?
-      @logger.info('Physical machine is always alive')
+    def run_studio(*)
+      Runner.new(@logger)
     end
 
-    def client_alive?(_name)
-      @logger.info('Physical machine is always alive')
+    def run_client(*)
+      Runner.new(@logger)
     end
 
-    def keep_studio_alive
-      @logger.info('Physical machine is always alive')
-    end
-
-    def keep_client_alive(_name)
-      @logger.info('Physical machine is always alive')
-    end
-
-    def clean_last_studio_run
-      @logger.info('Clean last run is currently not supported for physical machines')
-    end
-
-    def clean_last_client_run(_name)
-      @logger.info('Clean last run is currently not supported for physical machines')
-    end
-
-    def run_hck_studio(run_opts)
+    def run_hck_studio(scope, run_opts)
       studio_ip = @setup['st_ip']
-      @studio = HCKStudio.new(@project, self, run_opts) { studio_ip }
+      HCKStudio.new(self, scope, run_opts) { studio_ip }
     end
 
-    def run_hck_client(name, run_opts)
-      HCKClient.new(@project, self, @studio, name, run_opts)
-    end
-
-    def abort_studio
-      @logger.info('Abort is currently not supported for physical machines')
-    end
-
-    def abort_client(_name)
-      @logger.info('Abort is currently not supported for physical machines')
-    end
-
-    def close
-      @logger.info('Closing setup manager')
+    def run_hck_client(scope, studio, name, run_opts)
+      HCKClient.new(self, scope, studio, name, run_opts)
     end
   end
 end

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -13,7 +13,7 @@ module AutoHCK
         @logger = logger
       end
 
-      def alive?
+      def wait(...)
         @logger.info('Physical machine is always alive')
       end
 

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -107,8 +107,8 @@ module AutoHCK
         end
       end
 
-      def alive?
-        @qemu_thread.alive?
+      def wait(...)
+        @qemu_thread.join(...)
       end
 
       def soft_abort
@@ -134,7 +134,7 @@ module AutoHCK
       def vm_abort
         @keep_alive = false
 
-        return unless alive?
+        return unless @qemu_thread.alive?
 
         return if soft_abort
 

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -151,14 +151,6 @@ module AutoHCK
       @clients_vm[name].alive?
     end
 
-    def keep_studio_alive
-      @studio_vm.keep_alive
-    end
-
-    def keep_client_alive(name)
-      @clients_vm[name].keep_alive
-    end
-
     def clean_last_studio_run
       @studio_vm.clean_last_run
     end

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -186,12 +186,12 @@ module AutoHCK
       end
     end
 
-    def create_studio
-      @studio = HCKStudio.new(@project, self) { @studio_vm.find_world_ip }
+    def run_hck_studio(run_opts)
+      @studio = HCKStudio.new(@project, self, run_opts) { @studio_vm.find_world_ip }
     end
 
-    def create_client(name)
-      HCKClient.new(@project, self, @studio, name)
+    def run_hck_client(name, run_opts)
+      HCKClient.new(@project, self, @studio, name, run_opts)
     end
   end
 end

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -15,7 +15,6 @@ module AutoHCK
     attr_reader :kit
 
     OPT_NAMES = %w[viommu_state enlightenments_state vhost_state machine_type fw_type cpu].freeze
-    STUDIO = 'st'
 
     def initialize(project)
       initialize_project project
@@ -136,12 +135,12 @@ module AutoHCK
       @clients_vm[name].option_config(option)
     end
 
-    def run(name, run_opts = nil)
-      if name == STUDIO
-        @studio_vm.run(run_opts)
-      else
-        @clients_vm[name].run(run_opts)
-      end
+    def run_studio(run_opts = nil)
+      @studio_vm.run(run_opts)
+    end
+
+    def run_client(name, run_opts = nil)
+      @clients_vm[name].run(run_opts)
     end
 
     def studio_alive?

--- a/lib/setupmanagers/qemuhck/qmp.rb
+++ b/lib/setupmanagers/qemuhck/qmp.rb
@@ -11,17 +11,14 @@ module AutoHCK
     class QMP
       attr_reader :socket
 
-      def initialize(name, logger)
+      def initialize(scope, name, logger)
         @name = name
         @logger = logger
         @negotiated = false
         @logger.info("Initiating QMP session for #{name}")
         @socket, @socket_internal = UNIXSocket.pair
-      end
-
-      def close
-        @socket.close
-        @socket_internal.close
+        scope << @socket
+        scope << @socket_internal
       end
 
       def quit

--- a/lib/setupmanagers/setupmanager.rb
+++ b/lib/setupmanagers/setupmanager.rb
@@ -8,7 +8,7 @@ require './lib/setupmanagers/qemuhck/qemuhck'
 module AutoHCK
   # SetupManager
   #
-  class SetupManager
+  class SetupManager < SimpleDelegator
     attr_reader :id
 
     # SetupManagerFactory
@@ -32,88 +32,16 @@ module AutoHCK
       @project = project
       @logger = project.logger
       @type = project.config['setupmanager'].downcase.to_sym
-      setupmanager_create
+      super setupmanager_create
     end
 
     def setupmanager_create
       if SetupManagerFactory.can_create?(@type)
-        @setupmanager = SetupManagerFactory.create(@type, @project)
+        SetupManagerFactory.create(@type, @project)
       else
         @logger.warn("Unkown type setup manager #{@type}, Exiting...")
         raise SetupManagerError, "Unkown type setup manager #{@type}"
       end
-    end
-
-    def check_studio_image_exist
-      @setupmanager.check_studio_image_exist
-    end
-
-    def create_studio_image
-      @setupmanager.create_studio_image
-    end
-
-    def check_client_image_exist(name)
-      @setupmanager.check_client_image_exist(name)
-    end
-
-    def create_client_image(name)
-      @setupmanager.create_client_image(name)
-    end
-
-    def studio_option_config(option)
-      @setupmanager.studio_option_config(option)
-    end
-
-    def client_option_config(name, option)
-      @setupmanager.client_option_config(name, option)
-    end
-
-    def run(name, run_opts = {})
-      @setupmanager.run(name, run_opts)
-    end
-
-    def studio_alive?
-      @setupmanager.studio_alive?
-    end
-
-    def client_alive?(name)
-      @setupmanager.client_alive?(name)
-    end
-
-    def keep_studio_alive
-      @setupmanager.keep_studio_alive
-    end
-
-    def keep_client_alive(name)
-      @setupmanager.keep_client_alive(name)
-    end
-
-    def clean_last_studio_run
-      @setupmanager.clean_last_studio_run
-    end
-
-    def clean_last_client_run(name)
-      @setupmanager.clean_last_client_run(name)
-    end
-
-    def create_studio
-      @setupmanager.create_studio
-    end
-
-    def create_client(name)
-      @setupmanager.create_client(name)
-    end
-
-    def abort_studio
-      @setupmanager.abort_studio
-    end
-
-    def abort_client(name)
-      @setupmanager.abort_client(name)
-    end
-
-    def close
-      @setupmanager.close
     end
   end
 end

--- a/lib/trap.rb
+++ b/lib/trap.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'exceptions'
+
 # AutoHCK module
 module AutoHCK
   # Trap class
@@ -21,7 +23,7 @@ module AutoHCK
         write_log("SIG#{signal}(*) received, ignoring...")
       end
       @project&.handle_cancel
-      exit
+      raise AutoHCKInterrupt
     end
 
     @sig_timestamps = {}


### PR DESCRIPTION
I have already done several changes to improve the abortion logic, but I still see an error occurs during abortion. I also heard AutoHCK sometimes hangs after the tests finish, which imply some resources associated threads are left unreleased.

To eliminate this kind of errors completely, I propose `AutoHCK::ResourceScope` as a single true resource management mechanism.

This pull request makes *every* code dealing with unmanaged resources use the new mechanism so it's huge. Take time if it's correctly used everywhere before merging.