### PR TITLE
Run pre start command before each QEMU run

### DIFF
--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -101,6 +101,7 @@ module AutoHCK
                 Process.kill 'KILL', qemu.pid
                 qemu.wait_no_fail
               end
+              @machine.run_post_stop_commands
             end
 
             break unless @keep_alive
@@ -153,7 +154,6 @@ module AutoHCK
         return if @run_opts[:dump_only]
 
         vm_abort
-        @machine.run_post_stop_commands
         @machine.delete_snapshot if @delete_snapshot
       end
     end

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -86,12 +86,13 @@ module AutoHCK
 
       def run_vm
         @machine.dump_config
-        @machine.run_pre_start_commands
 
         @qemu_thread = Thread.new do
           loop do
             qemu = nil
             Thread.handle_interrupt(Object => :on_blocking) do
+              @machine.run_pre_start_commands
+
               qemu = run_qemu
               qemu.wait_no_fail
               qemu = nil


### PR DESCRIPTION
When QEMU exits, device daemons exit too, so we should run it again before start QEMU.