### PR TITLE
Define new HLK2022_next kit

### DIFF
--- a/lib/engines/hckinstall/kit.json
+++ b/lib/engines/hckinstall/kit.json
@@ -23,6 +23,9 @@
     "download_url": "https://go.microsoft.com/fwlink/?linkid=2195974",
     "extra_software": [ "winfsp" ]
   },
+  "HLK2022_next": {
+    "extra_software": [ "Disable_SNV", "winfsp" ]
+  },
   "HLK11_next": {
     "extra_software": [ "Disable_SNV", "winfsp" ]
   }

--- a/lib/engines/hckinstall/studio_platform.json
+++ b/lib/engines/hckinstall/studio_platform.json
@@ -1,5 +1,6 @@
 {
   "HLK11_next": "Win2022x64",
+  "HLK2022_next": "Win2022x64",
   "HLK11_22H2": "Win2022x64",
   "HLK2022": "Win2022x64",
   "HLK20H2": "Win2016x64",

--- a/lib/engines/hcktest/platforms/Win2022nextx64_host_uefi_q35_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2022nextx64_host_uefi_q35_viommu.json
@@ -1,26 +1,26 @@
 {
   "name": "Win2022nextx64_host_uefi_q35_viommu",
-  "kit": "HLK2022",
+  "kit": "HLK2022_next",
   "fw_type": "uefi",
   "machine_type": "q35",
   "viommu_state": true,
   "enlightenments_state": true,
   "cpu": "host",
-  "st_image": "HLK2022.qcow2",
+  "st_image": "HLK2022_next.qcow2",
   "clients": {
     "c1": {
       "name": "CL1",
       "cpus": "4",
       "memory": "8G",
       "winrm_port": "4002",
-      "image": "HLK2022-C1-Win2022nextx64-host-uefi-q35-viommu.qcow2"
+      "image": "HLK2022_next-C1-Win2022nextx64-host-uefi-q35-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
       "cpus": "4",
       "memory": "8G",
       "winrm_port": "4003",
-      "image": "HLK2022-C2-Win2022nextx64-host-uefi-q35-viommu.qcow2"
+      "image": "HLK2022_next-C2-Win2022nextx64-host-uefi-q35-viommu.qcow2"
     }
   }
 }


### PR DESCRIPTION
Windows Server vNext Build 25941 required other HLK and playlist.