### PR TITLE
Add PID to each CmdRun log

### DIFF
--- a/lib/auxiliary/cmd_run.rb
+++ b/lib/auxiliary/cmd_run.rb
@@ -10,7 +10,6 @@ module AutoHCK
     attr_reader :pid
 
     def initialize(logger, cmd, options = {})
-      logger.info("Run command: #{cmd}")
       @cmd = cmd
       @logger = logger
       @stdout = Tempfile.new
@@ -18,18 +17,19 @@ module AutoHCK
       @stderr = Tempfile.new
       @stderr.unlink
       @pid = spawn(@cmd, out: @stdout, err: @stderr, pgroup: 0, **options)
+      logger.info("Run command (PID #{@pid}): #{cmd}")
     end
 
     def wait(flags = 0)
       wait_for_status(flags) do |status|
-        e_message = "Failed to run: #{@cmd}"
+        e_message = "Failed to run (PID #{@pid}): #{@cmd}"
         raise CmdRunError, e_message unless status.exitstatus.zero?
       end
     end
 
     def wait_no_fail(flags = 0)
       wait_for_status(flags) do |status|
-        @logger.info("Command finished with code: #{status.exitstatus}")
+        @logger.info("Command finished with code (PID #{@pid}): #{status.exitstatus}")
       end
     end
 
@@ -52,8 +52,8 @@ module AutoHCK
         @stderr.rewind
         stderr = @stderr.read
 
-        @logger.info("Info dump:#{prep_log_stream(stdout)}") unless stdout.empty?
-        @logger.warn("Error dump:#{prep_log_stream(stderr)}") unless stderr.empty?
+        @logger.info("Info dump (PID #{@pid}):#{prep_log_stream(stdout)}") unless stdout.empty?
+        @logger.warn("Error dump (PID #{@pid}):#{prep_log_stream(stderr)}") unless stderr.empty?
       end
 
       yield status


### PR DESCRIPTION
When multiple commands start in parallel it is difficult to understand what exactly fails.