### PR TITLE
Bump AutoHCK version (0.13.0)

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 # AutoHCK module
 module AutoHCK
-  VERSION = '0.12.1'
+  VERSION = '0.13.0'
 end


### PR DESCRIPTION
There are a lot of changes in JSONs (refactoring/moving), that can break backward compatibility. Bump minor version.