### PR TITLE
Give meaningful names to test tap devices

### DIFF
--- a/lib/setupmanagers/qemuhck/network_manager.rb
+++ b/lib/setupmanagers/qemuhck/network_manager.rb
@@ -100,7 +100,7 @@ module AutoHCK
       def control_device_command(device_name, qemu_replacement_list = {})
         type = __method__.to_s.split('_').first
 
-        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no'
+        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no,ifname=@net_if_name@'
         network_backend = 'tap'
 
         options = {
@@ -117,7 +117,7 @@ module AutoHCK
       def world_device_command(device_name, qemu_replacement_list = {})
         type = __method__.to_s.split('_').first
 
-        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no'
+        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no,ifname=@net_if_name@'
         network_backend = 'tap'
 
         options = {
@@ -134,7 +134,7 @@ module AutoHCK
       def test_device_command(device_name, qemu_replacement_list = {})
         type = __method__.to_s.split('_').first
 
-        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no'
+        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no,ifname=@net_if_name@'
         network_backend = 'tap'
 
         options = {
@@ -153,7 +153,10 @@ module AutoHCK
 
         path = File.absolute_path(share_path)
 
-        netdev_options = ",net=#{transfer_net}.0/24,smb=#{path},smbserver=#{transfer_net}.4,restrict=on"
+        net_base = "#{transfer_net}.0/24"
+        smb_server = "#{transfer_net}.4"
+
+        netdev_options = "net=#{net_base},smb=#{path},smbserver=#{smb_server},restrict=on,ifname=@net_if_name@"
         network_backend = 'user'
 
         options = {


### PR DESCRIPTION
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: tap_host: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br_world state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether aa:c5:7d:6d:c6:a2 brd ff:ff:ff:ff:ff:ff
3: br_world: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 11000
    link/ether 2e:69:fe:af:28:ad brd ff:ff:ff:ff:ff:ff
4: br_ctrl: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 11000
    link/ether 4a:7b:69:83:c0:ed brd ff:ff:ff:ff:ff:ff
5: br_test: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 11000
    link/ether 02:4a:8c:3a:01:2a brd ff:ff:ff:ff:ff:ff
11: cs_r0002_c00: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br_ctrl state UNKNOWN mode DEFAULT group default qlen 11000
    link/ether 4a:7b:69:83:c0:ed brd ff:ff:ff:ff:ff:ff
12: ws_r0002_c00: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br_world state UNKNOWN mode DEFAULT group default qlen 11000
    link/ether 42:47:e7:24:88:8b brd ff:ff:ff:ff:ff:ff
13: cs_r0002_c01: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br_ctrl state UNKNOWN mode DEFAULT group default qlen 11000
    link/ether ba:4e:67:2d:86:ef brd ff:ff:ff:ff:ff:ff
14: ws_r0002_c01: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br_world state UNKNOWN mode DEFAULT group default qlen 11000
    link/ether 2e:69:fe:af:28:ad brd ff:ff:ff:ff:ff:ff
15: ts_r0002_c01: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br_test state UNKNOWN mode DEFAULT group default qlen 11000
    link/ether 02:4a:8c:3a:01:2a brd ff:ff:ff:ff:ff:ff
