### PR TITLE
update rtoolsHCK to 0.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'filelock'
 gem 'mono_logger'
 gem 'octokit'
 gem 'openssl', require: false
-gem 'rtoolsHCK', git: 'https://github.com/HCK-CI/rtoolsHCK.git', tag: 'v0.4.0'
+gem 'rtoolsHCK', git: 'https://github.com/HCK-CI/rtoolsHCK.git', tag: 'v0.4.1'
 gem 'rubyzip'
 gem 'sentry-ruby'
 gem 'sorbet-runtime'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/HCK-CI/rtoolsHCK.git
-  revision: c7159c573d79e0c367e256609b53ac011a70d31c
-  tag: v0.4.0
+  revision: d4233ce2b54f5bcf7925173d105e8de28c192c4f
+  tag: v0.4.1
   specs:
-    rtoolsHCK (0.4.0)
+    rtoolsHCK (0.4.1)
       bundler
       rdoc
       winrm (= 2.3.4)


### PR DESCRIPTION
I faced an errors without it 


`Invalid gemspec in [/home/jedoku/repos/AutoHCK.git/vendor/bundle/ruby/3.1.0/bundler/gems/rtoolsHCK-c7159c573d79/rtoolsHCK.gemspec]: uninitialized constant Gem::Specification::RToolsHCK
--- ERROR REPORT TEMPLATE -------------------------------------------------------

```
NoMethodError: undefined method `name' for nil:NilClass

    data.name
^^^^^`