### PR TITLE
Correct Tools closure timing

### DIFF
--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -16,9 +16,9 @@ module AutoHCK
       @tag = @project.engine.tag
       @ip_getter = ip_getter
       @logger = @project.logger
-      @scope = scope
       @logger.info('Starting studio')
       @runner = setup_manager.run_studio(scope, run_opts)
+      scope << self
     end
 
     def up?
@@ -53,7 +53,6 @@ module AutoHCK
       begin
         @logger.info('Initiating connection to studio')
         @tools = Tools.new(@project, @ip_getter.call, @clients)
-        @scope << @tools
       rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, RToolsHCKConnectionError
         raise StudioConnectError, 'Initiating connection to studio failed'
       end
@@ -90,6 +89,10 @@ module AutoHCK
     def shutdown
       @logger.info('Shutting down studio')
       @tools.shutdown
+    end
+
+    def close
+      @tools&.close
     end
   end
 end


### PR DESCRIPTION
HCKStudio keeps the reference to the Tools instance it creates so the referenced instance needs to be alive until HCKStudio dies. However, HCKStudio used to register a Tools instance to the ResourceScope when the instance gets created, which is later than the HCKStudio initialization. This implies the Tools instance gets closed earlier than HCKStudio, and HCKStudio will keep the dangling reference to the Tools instance.

This caused an exception in case
HCKTest::configure_setup_and_synchronize got interrupted. Such an interrupt first triggers the Tools instance closure earlier than the closure of the HCKStudio and HCKClient instances, and made HCKClient instances, which tries to use the Tools instance, fail.

Closing the Tools instance when HCKStudio dies extends its lifetime properly.