### PR TITLE
Initialize partition for viostor/vioblk testing

### DIFF
--- a/lib/engines/hcktest/drivers/vioscsi.json
+++ b/lib/engines/hcktest/drivers/vioscsi.json
@@ -13,6 +13,22 @@
     {
       "desc": "Make Disk Writable",
       "run": "Set-Disk -Number 1 -IsReadonly $False"
+    },
+    {
+      "desc": "Initialize Disk",
+      "run": "Initialize-Disk -Number 1 -PartitionStyle GPT"
+    },
+    {
+      "desc": "Remove Existing Partitions",
+      "run": "Remove-Partition -DiskNumber 1 -PartitionNumber 1 -Confirm:$false"
+    },
+    {
+      "desc": "Create Partition",
+      "run": "New-Partition -DiskNumber 1 -UseMaximumSize -AssignDriveLetter"
+    },
+    {
+      "desc": "Format Partition",
+      "run": "Format-Volume -DriveLetter (Get-Partition -DiskNumber 1).DriveLetter -FileSystem NTFS -Confirm:$false"
     }
   ],
   "reject_test_names": [

--- a/lib/engines/hcktest/drivers/viostor.json
+++ b/lib/engines/hcktest/drivers/viostor.json
@@ -13,6 +13,22 @@
     {
       "desc": "Make Disk Writable",
       "run": "Set-Disk -Number 1 -IsReadonly $False"
+    },
+    {
+      "desc": "Initialize Disk",
+      "run": "Initialize-Disk -Number 1 -PartitionStyle GPT"
+    },
+    {
+      "desc": "Remove Existing Partitions",
+      "run": "Remove-Partition -DiskNumber 1 -PartitionNumber 1 -Confirm:$false"
+    },
+    {
+      "desc": "Create Partition",
+      "run": "New-Partition -DiskNumber 1 -UseMaximumSize -AssignDriveLetter"
+    },
+    {
+      "desc": "Format Partition",
+      "run": "Format-Volume -DriveLetter (Get-Partition -DiskNumber 1).DriveLetter -FileSystem NTFS -Confirm:$false"
     }
   ],
   "reject_test_names": [


### PR DESCRIPTION
Initialize-Disk for some reason creates a small partition, so we must remove it before creating a new one. This behavior was tested on Server 2016/2022/2025. 