### PR TITLE
Bump AutoHCK version (0.15.0)

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 # AutoHCK module
 module AutoHCK
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end


### PR DESCRIPTION
Backward compatibility is broken, so bump a minor version.