### PR TITLE
Remove mount --make-rprivate / execution

### DIFF
--- a/bin/ns_unshared
+++ b/bin/ns_unshared
@@ -31,10 +31,6 @@ module AutoHCK
     r_read.close
 
     [
-      # unshare command recursively converts / to private by default, but we need to
-      # do that by ourselves because we use the bare unshare syscall.
-      ['mount', '--make-rprivate', '/'],
-
       ['mount', '--bind', File.join(__dir__, '..', 'etc', 'resolv.conf'), '/etc/resolv.conf'],
       %w[ip link set lo up],
       %w[ip link set tap_host up],


### PR DESCRIPTION
We use unshare command, which performs the identical operation since commit 86274a8518cebf8d4dc91aedd7079bd0ae75e9e6.