### PR TITLE
Continue run when can't load PR update 

### DIFF
--- a/lib/all.rb
+++ b/lib/all.rb
@@ -39,6 +39,7 @@ module AutoHCK
   autoload_relative :ExtraSoftwareMissingConfig, 'auxiliary/extra_software/exceptions'
   autoload_relative :Github, 'auxiliary/github'
   autoload_relative :GithubInitializationError, 'exceptions'
+  autoload_relative :GithubPullRequestLoadError, 'exceptions'
   autoload_relative :HCKClient, 'setupmanagers/hckclient'
   autoload_relative :HCKInstall, 'engines/hckinstall/hckinstall'
   autoload_relative :HCKStudio, 'setupmanagers/hckstudio'

--- a/lib/auxiliary/github.rb
+++ b/lib/auxiliary/github.rb
@@ -132,7 +132,7 @@ module AutoHCK
            Octokit::BadGateway, Octokit::InternalServerError => e
       @logger.warn("Github server connection error: #{e.message}")
       # we should fail if can't get updated PR information
-      raise unless (retries += 1) < GITHUB_API_RETRIES
+      raise GithubPullRequestLoadError, e unless (retries += 1) < GITHUB_API_RETRIES
 
       sleep GITHUB_API_RETRY_SLEEP
       @logger.info('Trying again execute github.pulls')

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -14,6 +14,8 @@ module AutoHCK
   # A custom GithubInitializationError error exception
   class GithubInitializationError < AutoHCKError; end
 
+  class GithubPullRequestLoadError < AutoHCKError; end
+
   # A custom Could not open json file exception
   class OpenJsonError < StandardError; end
 

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -128,8 +128,13 @@ module AutoHCK
     def check_run_termination
       return if @github.nil?
 
-      pr = @github.find_pr
-
+      begin
+        pr = @github.find_pr
+      rescue GithubPullRequestLoadError => e
+        @logger.warn("Error while checking PR status: #{e}")
+        @logger.warn('Continuing CI run, PR status will be checked later')
+        return
+      end
       # PR is nil when it was force-pushed
       # PR is closed when it was closed or merged
       @run_terminated = pr.nil? || @github.pr_closed?(pr)


### PR DESCRIPTION
Sometimes we got `Failed to open TCP connection to [api.github.com:443](http://api.github.com:443/) (getaddrinfo: Name or service not known)`  during CI run. 

If it happens at the start we should fail, because we can't get information about PR and don't know should we run tests or not.
If it happens during check_run_termination we can skip this iteration and AutoHCK will check again later. As CI time is several hours or even a day, this is not a problem to terminate CI not in one minute but in five.