### PR TITLE
tools: Use different sleep for HLK action and common action

### DIFF
--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -5,7 +5,8 @@ module AutoHCK
   # Tools class
   class Tools
     ACTION_RETRIES = 5
-    ACTION_RETRY_SLEEP = 10
+    HLK_ACTION_RETRY_SLEEP = 10
+    ACTION_RETRY_SLEEP = 90
     def initialize(project, ip_addr, clients)
       @logger = project.logger
       @config = project.config
@@ -100,11 +101,11 @@ module AutoHCK
         break if ret
 
         @logger.warn("Running HLK tools command (#{action}) failed")
-        sleep ACTION_RETRY_SLEEP
+        sleep HLK_ACTION_RETRY_SLEEP
         @logger.info("Trying again to run HLK tools command (#{action})")
       rescue StandardError => e
         @logger.warn("Running HLK tools command (#{action}) failed with #{e}")
-        sleep ACTION_RETRY_SLEEP
+        sleep HLK_ACTION_RETRY_SLEEP
         @logger.info("Trying again to run HLK tools command (#{action})")
       end
 


### PR DESCRIPTION
All HLK actions are sent to Studio VM that always alive. Common actions can be send to both Studio and Client VMs. Some action are sent after Windows BSOD, so we need time to Windows will boot again and WinRM service start.