### PR TITLE
Dropbox: Handle OAuth2::ConnectionError as Faraday::ConnectionFailed

### DIFF
--- a/lib/resultuploaders/dropbox/dropbox.rb
+++ b/lib/resultuploaders/dropbox/dropbox.rb
@@ -44,7 +44,7 @@ module AutoHCK
       else
         yield
       end
-    rescue Faraday::ConnectionFailed
+    rescue Faraday::ConnectionFailed, OAuth2::ConnectionError
       @logger.warn("Dropbox connection lost while #{where}")
       raise unless (retries += 1) < @action_retries
 


### PR DESCRIPTION
Currently, Dropbox API can raise OAuth2::ConnectionError when failed to resolve DNS name.