### PR TITLE
NetKVM: Update reject test names

### DIFF
--- a/lib/engines/hcktest/drivers/NetKVM.json
+++ b/lib/engines/hcktest/drivers/NetKVM.json
@@ -12,11 +12,6 @@
     }
   ],
   "reject_test_names": [
-    "[NdisStudio] NdisPoll keyword functional validation",
-    "[NdisStudio] OidRequestTest - OID_GEN_VENDOR_DRIVER_VERSION Verification",
-    "[NdisStudio] NdisPoll keyword validation",
-    "[NdisStudio] OidRequestTest - OID_GEN_XMIT_OK and OID_GEN_RCV_OK Verification",
-    "[NdisStudio] OidRequestTest - OID_GEN_VENDOR_ID Verification",
     "NDISTest 6.5 - [2 Machine] - MPE_Ethernet.xml",
     "NDISTest 6.0 - [1 Machine] - 1c_Mini6RSSOids",
     "PrivateCloudSimulator - Device.Network.LAN.10GbOrGreater",


### PR DESCRIPTION
According to release notes:
https://techcommunity.microsoft.com/blog/windowshardwarecertification/hlk-feb-refresh-release-for-windows-11-version-24h2-and-windows-server-2025/4382661