### PR TITLE
Fix dropbox enter authorization code

### DIFF
--- a/lib/resultuploaders/dropbox/dropbox.rb
+++ b/lib/resultuploaders/dropbox/dropbox.rb
@@ -69,7 +69,7 @@ module AutoHCK
       @logger.info("Navigate to #{url}")
       @logger.info('Please enter authorization code')
 
-      code = gets.chomp
+      code = $stdin.gets.chomp
       @token = @authenticator.auth_code.get_token(code)
 
       save_token(@token)


### PR DESCRIPTION
`I, [2025-03-03T05:52:13.414770 #333237]  INFO -- : Navigate to https://www.dropbox.com/oauth2/authorize?client_id=vah03z3dsrd4f3w&response_type=code&token_access_type=offline
I, [2025-03-03T05:52:13.414861 #333237]  INFO -- : Please enter authorization code
F, [2025-03-03T05:52:13.415000 #333237] FATAL -- : (Errno::ENOENT) No such file or directory @ rb_sysopen - config
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/resultuploaders/dropbox/dropbox.rb:72:in `gets'
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/resultuploaders/dropbox/dropbox.rb:72:in `gets'
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/resultuploaders/dropbox/dropbox.rb:72:in `ask_token'
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/resultuploaders/result_uploader.rb:49:in `each_value'
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/resultuploaders/result_uploader.rb:49:in `ask_token'
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/engines/config_manager/config_manager.rb:25:in `block in run'
   -- /home/jedoku/HCK/repos/AutoHCK.git/lib/auxiliary/resource_scope.rb:29:in `block (2 levels) i`