### PR TITLE
RHELMISC-10178: test: Match test names as regexp

### DIFF
--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -136,7 +136,7 @@ module AutoHCK
       tests_config = @project.engine.config.tests_config + @project.engine.drivers.flat_map(&:tests_config)
 
       tests_config
-        .select { Regexp.union(_1.tests).match?(test_name) }
+        .select { |test_config| Regexp.union(test_config.tests.map { Regexp.new(_1) }).match?(test_name) }
         .flat_map(&config)
     end
 


### PR DESCRIPTION
Fix 54a1c0a2b968f4427035940e563f24098d99eb04.

Regexp.union has escape symbols in string for some undocumented reason.
3.3.7 :001 > x = Regexp.new("asd|.*")
 => /asd|.*/
3.3.7 :002 > y = Regexp.union(["asd", ".*"])
 => /asd|\.\*/
3.3.7 :003 >

3.3.7 :002 > x = Regexp.new(".*")
 => /.*/
3.3.7 :003 > y = Regexp.new("sdsd")
 => /sdsd/
3.3.7 :004 > z = Regexp.union(x, y)
 => /(?-mix:.*)|(?-mix:sdsd)/