### PR TITLE
RHELMISC-10658: Implement log upload to external FS

### DIFF
--- a/lib/project.rb
+++ b/lib/project.rb
@@ -14,6 +14,7 @@ module AutoHCK
     def initialize(scope, options)
       @scope = scope
       @options = options
+      init_timestamp
       Json.update_json_override(options.common.config) unless options.common.config.nil?
       init_multilog(options.common.verbose)
       init_class_variables
@@ -74,9 +75,17 @@ module AutoHCK
       @logger.add_logger(@pre_logger)
     end
 
+    def init_timestamp
+      unless @options.common.workspace_path.nil?
+        @timestamp = @options.common.workspace_path.split('/').last
+        return
+      end
+
+      @timestamp = current_timestamp
+    end
+
     def init_class_variables
       @config = Config.read
-      @timestamp = current_timestamp
       @engine_name = @config["#{@options.mode}_engine"]
       @engine_type = Engine.select(@engine_name)
       @engine_tag = @engine_type.tag(@options)

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -19,6 +19,11 @@ module AutoHCK
       init_class_variables
       init_workspace
       @id = options.common.id
+      # ResultUploader must be initialized before adding project to scope
+      # Project uses ResultUploader on close, so ResultUploader must exist
+      # when project is closed
+      @result_uploader = ResultUploader.new(@scope, self)
+
       scope << self
     end
 
@@ -82,7 +87,6 @@ module AutoHCK
 
     def configure_result_uploader
       @logger.info('Initializing result uploaders')
-      @result_uploader = ResultUploader.new(@scope, self)
       @result_uploader.connect
       @result_uploader.create_project_folder
     end

--- a/lib/resultuploaders/fs_copy/fs_copy.json
+++ b/lib/resultuploaders/fs_copy/fs_copy.json
@@ -1,0 +1,4 @@
+{
+    "host_path": "/mnt/nfs",
+    "base_url": "http://nfs-server.local:8080/"
+}

--- a/lib/resultuploaders/fs_copy/fs_copy.rb
+++ b/lib/resultuploaders/fs_copy/fs_copy.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module AutoHCK
+  class FsCopy
+    CONFIG_JSON = 'lib/resultuploaders/fs_copy/fs_copy.json'
+
+    include Helper
+
+    attr_reader :url
+
+    def initialize(project)
+      @logger = project.logger
+
+      @config = Json.read_json(CONFIG_JSON, @logger)
+
+      @host_path = @config['host_path']
+      base_url = @config['base_url']
+
+      work_path = "auto_hck/#{project.config['repository']}/#{project.engine_tag}/#{project.timestamp}"
+
+      @path = "#{@host_path}/#{work_path}"
+      @url = "#{base_url}/#{work_path}" unless base_url.nil?
+    end
+
+    def html_url; end
+
+    def handle_exceptions(where)
+      yield
+    rescue StandardError => e
+      @logger.warn("FS #{where} error: #{e.detailed_message}")
+      false
+    end
+
+    # These methods are intentionally left blank to maintain the interface,
+    # as FsCopy does not require this function. It prevents external calls
+    # from causing errors while adhering to the expected API structure.
+    def ask_token; end
+
+    def connect
+      File.exist?(@host_path)
+    end
+
+    def create_project_folder
+      handle_exceptions(__method__) do
+        FileUtils.mkdir_p(@path)
+        @logger.info("FS project folder created: #{@url}")
+      end
+    end
+
+    def upload_file(l_path, r_name)
+      handle_exceptions(__method__) do
+        r_path = "#{@path}/#{r_name}"
+        FileUtils.copy(l_path, r_path)
+      end
+    end
+
+    def update_file_content(content, r_name)
+      handle_exceptions(__method__) do
+        r_path = "#{@path}/#{r_name}"
+        File.write(r_path, content)
+      end
+    end
+
+    def delete_file(r_name)
+      handle_exceptions(__method__) do
+        r_path = "#{@path}/#{r_name}"
+        FileUtils.remove(r_path)
+        @logger.info("FS file deleted: #{r_path}")
+        true
+      rescue Errno::ENOENT
+        false
+      end
+    end
+  end
+end

--- a/lib/resultuploaders/result_uploader.rb
+++ b/lib/resultuploaders/result_uploader.rb
@@ -38,7 +38,7 @@ module AutoHCK
       @uploaders = {}
       @project.config['result_uploaders'].uniq.each do |type|
         if UploaderFactory.can_create?(type)
-          @uploaders[type] = UploaderFactory.create(type, @project)
+          @scope << (@uploaders[type] = UploaderFactory.create(type, @project))
         else
           @project.logger.info("Unknown type uploader #{type}, (ignoring)")
         end
@@ -53,7 +53,6 @@ module AutoHCK
       @uploaders.each_pair do |type, uploader|
         if uploader.connect
           @connected_uploaders[type] = uploader
-          @scope << uploader
         else
           @project.logger.info("#{type} connection failed, (ignoring)")
         end


### PR DESCRIPTION
Can be used to mount NFS storage and upload logs to it.

~~This PR is a draft due to an issue with AutoHCK.log uploading.
As a result uploaders are created after the Project, we close them before closing the project. 
It caused the problem, that AutoHCK.log must be uploaded after result uploaders were closed.
We did not see any errors before, because `def close` is empty in Dropbox/S3 uploaders but even logically this is a problem.~~

```
I, [2025-03-27T20:45:58.530397 #58880]  INFO -- CmdRun PID:73517: Command finished with code 0
I, [2025-03-27T20:45:58.541493 #58880]  INFO -- CmdRun PID:73521: Run command: gio mount 'smb://WORKGROUP;iadmin@10.7.2.11/kostyanf14' --unmount
I, [2025-03-27T20:45:58.557758 #58880]  INFO -- CmdRun PID:73521: stderr: 
I, [2025-03-27T20:45:58.558214 #58880]  INFO -- CmdRun PID:73521: stderr: (gio mount:73521): GVFS-WARNING **: 20:45:58.557: The peer-to-peer connection failed: Exhausted all available authentication mechanisms (tried: EXTERNAL) (available: EXTERNAL). Falling back to the session bus. Your application is probably missing --filesystem=xdg-run/gvfsd privileges.
I, [2025-03-27T20:45:58.561212 #58880]  INFO -- CmdRun PID:73521: Command finished with code 0
D, [2025-03-27T20:45:58.561406 #58880] DEBUG -- : Closing AutoHCK project
W, [2025-03-27T20:45:58.561955 #58880]  WARN -- : FS upload_file error: No such file or directory @ rb_sysopen - /run/user/1000/gvfs/smb-share:domain=WORKGROUP,server=10.7.2.11,share=kostyanf14,user=iadmin//auto_hck/kostyanf14/test1/NetKVM-Win11_24H2x64_host_viommu/2025_03_27_19_39_29/AutoHCK.log (Errno::ENOENT)
```

~~As an idea, we can initialize result uploaders before to project, then configure them to load data from the project and then we will close it after the project.~~
@akihikodaki @Jedoku Any comments/suggestions?
