### PR TITLE
RHELMISC-11270: QemuHCK: Attach control network device to pcie-root-port

### DIFF
--- a/lib/setupmanagers/qemuhck/machine.json
+++ b/lib/setupmanagers/qemuhck/machine.json
@@ -1,12 +1,12 @@
 {
   "q35": {
-    "bus_name": "root1",
-    "ctrl_bus_name": "pcie",
+    "bus_name": "root2",
+    "ctrl_bus_name": "root1",
     "disable_s3_param": "ICH9-LPC.disable_s3",
     "disable_s4_param": "ICH9-LPC.disable_s4",
     "machine_uuid__comment": "Windows 2012R2 crashes during boot on Q35 machine with UUID set",
     "machine_uuid": "-uuid cdef127c-8795-4e67-95da-8dd0a8@run_id@@client_id@",
-    "pcie_root_port": "-device pcie-root-port,slot=3,chassis=1,addr=0x4,bus=pcie.0,id=root1.0"
+    "pcie_root_port": "-device pcie-root-port,slot=3,chassis=1,addr=0x4,bus=pcie.0,id=root1.0 -device pcie-root-port,slot=4,chassis=2,addr=0x5,bus=pcie.0,id=root2.0"
   },
   "pc": {
     "bus_name": "pci",

--- a/lib/setupmanagers/qemuhck/network_manager.json
+++ b/lib/setupmanagers/qemuhck/network_manager.json
@@ -4,7 +4,7 @@
       "ifname": "cs_r@run_id@_c@client_id@",
       "mac": "56:@run_id_first@:@run_id_second@:@client_id@:cc:cc",
       "bus_name": "@ctrl_bus_name@",
-      "address": "03"
+      "address": "0x0"
     },
     "world": {
       "ifname": "ws_r@run_id@_c@client_id@",


### PR DESCRIPTION
This allows to use NetKVM as a control network device with IOMMU enabled.

virtio-pci swithes to legacy mode, when device attached to pcie bus instead of root port.

This brake backward compatibility as a PCI topology changes and Windows reconfigure devices.