### PR TITLE
RHELMISC-12099: Update HLK kit urls

### DIFF
--- a/lib/engines/hckinstall/kits/HLK11_22H2.json
+++ b/lib/engines/hckinstall/kits/HLK11_22H2.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2250318",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2320114",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK11_23H2.json
+++ b/lib/engines/hckinstall/kits/HLK11_23H2.json
@@ -1,5 +1,4 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2250318",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK11_24H2.json
+++ b/lib/engines/hckinstall/kits/HLK11_24H2.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2301919",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2320012",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK1809.json
+++ b/lib/engines/hckinstall/kits/HLK1809.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2311783",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2319329",
   "extra_software": [
     "HLK_GRFX_FOD",
     "WDTFNetData_1809",

--- a/lib/engines/hckinstall/kits/HLK1809server.json
+++ b/lib/engines/hckinstall/kits/HLK1809server.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2311783",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2319329",
   "extra_software": [
     "FOD_2019",
     "HLK_GRFX_FOD",

--- a/lib/engines/hckinstall/kits/HLK2004.json
+++ b/lib/engines/hckinstall/kits/HLK2004.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2128655",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2320002",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK2022.json
+++ b/lib/engines/hckinstall/kits/HLK2022.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2164257",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2320003",
   "extra_software": [
     "FOD_2022",
     "Test-NETHLK",

--- a/lib/engines/hckinstall/kits/HLK2025.json
+++ b/lib/engines/hckinstall/kits/HLK2025.json
@@ -1,5 +1,5 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/?linkid=2301919",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2320012",
   "extra_software": [
     "Test-NETHLK",
     "winfsp",


### PR DESCRIPTION
HLK for Win11 23H2 was removed.
