### PR TITLE
RHELMISC-15655: Update HLK kits

### DIFF
--- a/lib/engines/hckinstall/kits/HLK11_22H2.json
+++ b/lib/engines/hckinstall/kits/HLK11_22H2.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2320114",
+  "sha256": "b283fe38119248ade6f6b925b90434587c738f5f91d295489cf6bf0c32415ee2",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK11_24H2.json
+++ b/lib/engines/hckinstall/kits/HLK11_24H2.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2320012",
+  "sha256": "6c20e20cee9288eb5023bb926eb10fd0c46ef34f6fbca764d80bc3504c3687b1",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK1607.json
+++ b/lib/engines/hckinstall/kits/HLK1607.json
@@ -1,5 +1,6 @@
 {
-  "download_url": "https://go.microsoft.com/fwlink/p/?LinkID=404112",
+  "download_url": "https://go.microsoft.com/fwlink/?linkid=2327101",
+  "sha256": "a4dbd0e002ca405db7d30a375221edd4c12fd5a1952c311691ba94e7891a7ddb",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK1809.json
+++ b/lib/engines/hckinstall/kits/HLK1809.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2319329",
+  "sha256": "32f21c5adf58afbe5e6346bd31d8baad920204e2dce1a57ba5b04b2b4b22ba2b",
   "extra_software": [
     "HLK_GRFX_FOD",
     "WDTFNetData_1809",

--- a/lib/engines/hckinstall/kits/HLK1809server.json
+++ b/lib/engines/hckinstall/kits/HLK1809server.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2319329",
+  "sha256": "32f21c5adf58afbe5e6346bd31d8baad920204e2dce1a57ba5b04b2b4b22ba2b",
   "extra_software": [
     "FOD_2019",
     "HLK_GRFX_FOD",

--- a/lib/engines/hckinstall/kits/HLK2004.json
+++ b/lib/engines/hckinstall/kits/HLK2004.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2320002",
+  "sha256": "157a479ca2caab9f96a92bf9453cf19aabfc286f2450bb0084eaa8c0f787b6ee",
   "extra_software": [
     "winfsp"
   ],

--- a/lib/engines/hckinstall/kits/HLK2022.json
+++ b/lib/engines/hckinstall/kits/HLK2022.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2320003",
+  "sha256": "fe6418b76a94b1103a69b5fdd7549871b467c35e00be646677cd0de841609170",
   "extra_software": [
     "FOD_2022",
     "Test-NETHLK",

--- a/lib/engines/hckinstall/kits/HLK2025.json
+++ b/lib/engines/hckinstall/kits/HLK2025.json
@@ -1,5 +1,6 @@
 {
   "download_url": "https://go.microsoft.com/fwlink/?linkid=2320012",
+  "sha256": "6c20e20cee9288eb5023bb926eb10fd0c46ef34f6fbca764d80bc3504c3687b1",
   "extra_software": [
     "Test-NETHLK",
     "winfsp",

--- a/lib/models/kit.rb
+++ b/lib/models/kit.rb
@@ -12,6 +12,7 @@ module AutoHCK
       const :extra_software, T::Array[String], default: []
 
       const :download_url, T.nilable(String)
+      const :sha256, T.nilable(String)
     end
   end
 end

--- a/spec/kit_spec.rb
+++ b/spec/kit_spec.rb
@@ -1,23 +1,28 @@
 require_relative '../lib/all'
+require 'digest'
 
 describe 'kit_spec' do
   Dir['./lib/engines/hckinstall/kits/*.json'].each do |json_file|
-    kit_url = AutoHCK::Models::Kit.from_json_file(json_file).download_url
+    kit = AutoHCK::Models::Kit.from_json_file(json_file)
+    kit_url = kit.download_url
     next if kit_url.nil?
 
     it "Kit for #{json_file} can be downloaded" do
       content = String.new
 
+      file_type = nil
       HTTPClient.get_content(kit_url) do |chunk|
         content << chunk
-        break if content.size > 32_773
+        file_type ||= 'exe' if content[0..1] == 'MZ'
+        # For ISOs, we only need the header. For EXEs, we need the whole file for checksum.
+        if content.size > 32_773 # Check for ISO header
+          file_type ||= 'iso' if content[32_769..32_773] == 'CD001'
+          break unless file_type == 'exe'
+        end
       end
 
-      file_type = nil
-      file_type = 'exe' if content[0..1] == 'MZ'
-      file_type = 'iso' if content[32_769..32_773] == 'CD001'
-
       expect(%w[exe iso]).to include(file_type)
+      expect(Digest::SHA256.hexdigest(content)).to eq(kit.sha256) if file_type == 'exe'
     end
   end
 end


### PR DESCRIPTION
Add sha256 for kits that provide online exe installer, because last time MS update kits without updating link. This cause problem that new kit silently was installed.