### PR TITLE
Dropbox: Remove share_folder call

### DIFF
--- a/lib/resultuploaders/dropbox/dropbox.rb
+++ b/lib/resultuploaders/dropbox/dropbox.rb
@@ -125,7 +125,6 @@ module AutoHCK
         rescue DropboxApi::Errors::FolderConflictError
           @logger.warn("Dropbox project folder already exists: #{@path}")
         end
-        @dropbox.share_folder(@path)
         @url = "#{@dropbox.create_shared_link_with_settings(@path).url}&lst="
         @logger.info("Dropbox project folder created: #{@url}")
       end


### PR DESCRIPTION
share_folder - Share a folder with collaborators
(other Dropbox accounts).
This endpoint does not support apps with the app folder permission.

create_shared_link_with_settings - Create a shared link with custom settings. If no settings are given then the default visibility is RequestedVisibility.public (The resolved visibility, though, may depend on other aspects such as team and shared folder settings).