### PR TITLE
viostor/vioscsi: Ignore remove partition fail

### DIFF
--- a/lib/engines/hcktest/drivers/vioscsi.json
+++ b/lib/engines/hcktest/drivers/vioscsi.json
@@ -27,7 +27,7 @@
       "pre_test_commands": [
         {
           "desc": "Remove Existing Partitions",
-          "guest_run": "Remove-Partition -DiskNumber 1 -PartitionNumber 1 -Confirm:$false"
+          "guest_run": "Remove-Partition -DiskNumber 1 -PartitionNumber 1 -Confirm:$false -ErrorAction Continue; exit 0"
         },
         {
           "desc": "Create Partition",

--- a/lib/engines/hcktest/drivers/viostor.json
+++ b/lib/engines/hcktest/drivers/viostor.json
@@ -27,7 +27,7 @@
       "pre_test_commands": [
         {
           "desc": "Remove Existing Partitions",
-          "guest_run": "Remove-Partition -DiskNumber 1 -PartitionNumber 1 -Confirm:$false"
+          "guest_run": "Remove-Partition -DiskNumber 1 -PartitionNumber 1 -Confirm:$false -ErrorAction Continue; exit 0"
         },
         {
           "desc": "Create Partition",


### PR DESCRIPTION
In some case, HLK test can finishes after removing partition. In this case, AutoHCK should not fail run and just create a new partition.