### PR TITLE
auto_hck: handle all errors in the main wrapper safely

### DIFF
--- a/bin/auto_hck
+++ b/bin/auto_hck
@@ -23,11 +23,16 @@ module AutoHCK
       @project.run if @project.prepare
     rescue StandardError => e
       Signal.trap('TERM') do
-        @project.logger.warn('SIGTERM(*) received, ignoring...')
+        @project&.logger&.warn('SIGTERM(*) received, ignoring...')
       end
       Sentry.capture_exception(e)
-      @project.log_exception(e, 'fatal')
-      @project.handle_error
+      if @project
+        @project.log_exception(e, 'fatal')
+        @project.handle_error
+      else
+        estack = e.backtrace.map { |line| "\n   -- #{line.rstrip}" }.join
+        warn "fatal: (#{e.class}) #{e.message}#{estack}"
+      end
       exit(1)
     end
   end


### PR DESCRIPTION
AutoHCK can be interupted or Project can raise error before logger initialized. To prevent generating an additional exception check that @project is not nil.