### PR TITLE
Add --no-reboot-after-bugcheck option for crash debugging

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -201,7 +201,7 @@ module AutoHCK
 
     # class InstallOptions
     class InstallOptions
-      attr_accessor :platform, :force, :skip_client, :drivers, :driver_path, :debug
+      attr_accessor :platform, :force, :skip_client, :drivers, :driver_path, :debug, :no_reboot_after_bugcheck
 
       def create_parser
         OptionParser.new do |parser|
@@ -221,6 +221,7 @@ module AutoHCK
         @skip_client = false
         @drivers = []
         @debug = false
+        @no_reboot_after_bugcheck = false
 
         parser.on('--debug', TrueClass, 'Enable debug mode',
                   &method(:debug=))
@@ -244,6 +245,10 @@ module AutoHCK
         parser.on('--driver-path <driver_path>', String,
                   'Path to the location of the driver wanted to be installed',
                   &method(:driver_path=))
+
+        parser.on('--no-reboot-after-bugcheck', TrueClass,
+                  'Keep system in crashed state after crash for debugging (disables automatic reboot)',
+                  &method(:no_reboot_after_bugcheck=))
       end
       # rubocop:enable Metrics/MethodLength
     end

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -247,7 +247,8 @@ module AutoHCK
       config = {
         kit_type:,
         hlk_kit_ver: kit_version,
-        debug: @project.options.install.debug
+        debug: @project.options.install.debug,
+        no_reboot_after_bugcheck: @project.options.install.no_reboot_after_bugcheck
       }
 
       @kit_path = find_kit(kit_type, kit_version)

--- a/lib/engines/hckinstall/setup_scripts_helper.rb
+++ b/lib/engines/hckinstall/setup_scripts_helper.rb
@@ -8,7 +8,8 @@ module AutoHCK
       kit_type: '',
       hlk_kit_ver: '',
       remove_gui: '',
-      debug: ''
+      debug: '',
+      no_reboot_after_bugcheck: ''
     }.freeze
 
     def validate_setup_scripts_config(config)


### PR DESCRIPTION
This option allows keeping systems in crashed state after bugcheck instead of automatically rebooting, enabling better debugging of system crashes during HCK installation and testing.