### PR TITLE
VIRTWINKVM-1855：Add --tag-suffix option to prevent tag name conflicts

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -95,7 +95,7 @@ module AutoHCK
       attr_accessor :platform, :drivers, :driver_path, :commit, :svvp, :dump,
                     :gthb_context_prefix, :gthb_context_suffix, :playlist, :select_test_names,
                     :reject_test_names, :reject_report_sections, :boot_device,
-                    :allow_test_duplication, :manual, :package_with_playlist, :enable_vbs
+                    :allow_test_duplication, :manual, :package_with_playlist, :enable_vbs, :tag_suffix
 
       def create_parser
         OptionParser.new do |parser|
@@ -195,6 +195,10 @@ module AutoHCK
         parser.on('--package-with-playlist', TrueClass,
                   'Load playlist into HLKX project package',
                   &method(:package_with_playlist=))
+
+        parser.on('--tag-suffix <tag_suffix>', String,
+                  'Add custom suffix to HCK-CI tag to prevent name conflicts when using shared controller',
+                  &method(:tag_suffix=))
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
     end

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -216,10 +216,18 @@ module AutoHCK
     end
 
     def self.tag(options)
-      if options.test.svvp
-        "svvp-#{options.test.platform}"
+      base_tag = if options.test.svvp
+                   "svvp-#{options.test.platform}"
+                 else
+                   "#{options.test.drivers.sort.join('-')}-#{options.test.platform}"
+                 end
+
+      # Append tag_suffix if provided to prevent name conflicts when using shared controller
+      suffix = options.test.tag_suffix&.strip
+      if suffix && !suffix.empty?
+        "#{base_tag}-#{suffix}"
       else
-        "#{options.test.drivers.sort.join('-')}-#{options.test.platform}"
+        base_tag
       end
     end
 


### PR DESCRIPTION
  1. Add new --tag-suffix CLI option to allow custom tag suffixes
  2. Modify tag generation in HCKTest to append suffix when provided
  3. Prevents naming conflicts when multiple users share a controller