### PR TITLE
Add support for including driver and supplemental files in HLKX package

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -92,9 +92,9 @@ module AutoHCK
 
     # class TestOptions
     class TestOptions
-      attr_accessor :platform, :drivers, :driver_path, :commit, :svvp, :dump,
-                    :gthb_context_prefix, :gthb_context_suffix, :playlist, :select_test_names,
-                    :reject_test_names, :reject_report_sections, :boot_device,
+      attr_accessor :platform, :drivers, :driver_path, :supplemental_path, :package_with_driver,
+                    :commit, :svvp, :dump, :gthb_context_prefix, :gthb_context_suffix, :playlist,
+                    :select_test_names, :reject_test_names, :reject_report_sections, :boot_device,
                     :allow_test_duplication, :manual, :package_with_playlist, :enable_vbs, :tag_suffix,
                     :fs_test_image_format
 
@@ -127,6 +127,14 @@ module AutoHCK
         parser.on('--driver-path <driver_path>', String,
                   'Path to the location of the driver wanted to be tested',
                   &method(:driver_path=))
+
+        parser.on('--supplemental-path <supplemental_path>', String,
+                  'Path to the supplemental content folder (e.g. for README)',
+                  &method(:supplemental_path=))
+
+        parser.on('--package-with-driver', TrueClass,
+                  'Include driver files in HLKX package (requires --driver-path)',
+                  &method(:package_with_driver=))
 
         parser.on('-c', '--commit <commit_hash>', String,
                   'Commit hash for CI status update',

--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -198,6 +198,18 @@ module AutoHCK
       retry
     end
 
+    def upload_to_studio(l_path, r_path)
+      retries ||= 0
+      act_with_tools { _1.upload_to_studio(l_path, r_path) }
+    rescue ToolsHCKError => e
+      @logger.warn(e.message)
+      raise UploadToMachineError, 'Upload to studio failed' unless (retries += 1) < ACTION_RETRIES
+
+      sleep ACTION_RETRY_SLEEP
+      @logger.info('Trying again upload to studio')
+      retry
+    end
+
     def download_from_machine(machine, r_path, l_path)
       retries ||= 0
       act_with_tools { _1.download_from_machine(machine, r_path, l_path) }
@@ -366,9 +378,9 @@ module AutoHCK
       retry
     end
 
-    def create_project_package(project, playlist = nil, handler = nil)
+    def create_project_package(project, playlist = nil, handler = nil, driver_path = nil, supplemental_path = nil) # rubocop:disable Metrics/ParameterLists
       retry_tools_command(__method__) do
-        act_with_tools { _1.create_project_package(project, playlist, handler) }
+        act_with_tools { _1.create_project_package(project, playlist, handler, driver_path, supplemental_path) }
       end
     end
 


### PR DESCRIPTION
- Add --supplemental-path argument to specify supplemental content folder
- Add --package-with-driver flag to enable driver inclusion in package
- Add upload_to_studio method in tools.rb for uploading files to Studio
- Update create_project_package to upload and include driver/supplemental files