### PR TITLE
Workaround for Microsoft HLK 2022 unsigned driver issue

### DIFF
--- a/lib/engines/hckinstall/kits/HLK2022.json
+++ b/lib/engines/hckinstall/kits/HLK2022.json
@@ -4,7 +4,8 @@
   "extra_software": [
     "FOD_2022",
     "Test-NETHLK",
-    "winfsp"
+    "winfsp",
+    "NDIS_Driver_Fix"
   ],
   "studio_platform": "Win2019x64",
   "name": "HLK2022"


### PR DESCRIPTION
This commit implements a workaround to bypass the driver signing issue encountered in HLK 2022.

For more details, see: https://github.com/HCK-CI/AutoHCK/issues/819