### PR TITLE
Implement the GlitchFreeDevice workaround extension

### DIFF
--- a/lib/engines/hcktest/extensions/GlitchFreeDevice_NdisPollMode_workaround.json
+++ b/lib/engines/hcktest/extensions/GlitchFreeDevice_NdisPollMode_workaround.json
@@ -1,0 +1,24 @@
+{
+  "comments": [
+    "Workaround for NDISTest 6.5 GlitchFreeDevice test incompatibility with NDIS Poll Mode"
+  ],
+  "tests_config": [
+    {
+      "tests": [
+        "NDISTest 6.5 - \\[2 Machine\\] - GlitchFreeDevice"
+      ],
+      "pre_test_commands": [
+        {
+          "desc": "Disable Poll Mode for NetKVM driver to work around GlitchFreeDevice test issues",
+          "guest_run": "Set-NetAdapterAdvancedProperty -Name SupportDevice0 -DisplayName 'Ndis Poll Mode' -RegistryValue 0"
+        }
+      ],
+      "post_test_commands": [
+        {
+          "desc": "Re-enable Poll Mode for NetKVM driver after test completion",
+          "guest_run": "Set-NetAdapterAdvancedProperty -Name SupportDevice0 -DisplayName 'Ndis Poll Mode' -RegistryValue 1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
HLK test NDISTest 6.5 - [2 Machine] - GlitchFreeDevice for NetKVM is incompatible with NDIS Poll Mode, while Windows 11/Windows Server 2025 requires NDIS Poll Mode to be implemented and enabled by default.

We can't just add the test to the reject list because it really works on other systems, and AutoHCK does not have an API to reject the test per HLK version.

Let's use a new extension mechanism to allow AutoHCK users enable a workaround manually when running tests for Windows 11/Windows Server 2025.

Previously, the GlitchFreeDevice test was filtered with MSFT HCK filters, but not now. This workaround will be removed when HLK for Windows 11/Windows Server 2025 starts support for Poll Mode, or MSFT releases new filters.