### PR TITLE
hlkinstall: Allow load HLK ISO from general ISO path

### DIFF
--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -286,7 +286,8 @@ module AutoHCK
       installers = [
         "#{@hck_setup_scripts_path}/Kits/#{kit_type}#{kit_version}Setup.exe",
         "#{@hck_setup_scripts_path}/Kits/#{kit_type}#{kit_version}/#{kit_type}Setup.exe",
-        "#{@hck_setup_scripts_path}/Kits/#{kit_type}#{kit_version}Setup.iso"
+        "#{@hck_setup_scripts_path}/Kits/#{kit_type}#{kit_version}Setup.iso",
+        "#{@iso_path}/#{kit_type}#{kit_version}Setup.iso"
       ]
 
       installers.find { File.exist? _1 }


### PR DESCRIPTION
HLK ISO is also ISO, no need to limit it to setup scripts dir.