### PR TITLE
VIRTWINKVM-2071: Automate Hardware-enforced Stack Protection Compatibility Test

### DIFF
--- a/lib/engines/hckinstall/kits/HLK2022.json
+++ b/lib/engines/hckinstall/kits/HLK2022.json
@@ -5,7 +5,8 @@
     "FOD_2022",
     "Test-NETHLK",
     "winfsp",
-    "NDIS_Driver_Fix"
+    "NDIS_Driver_Fix",
+    "autoit"
   ],
   "studio_platform": "Win2019x64",
   "name": "HLK2022"

--- a/lib/engines/hcktest/drivers/Balloon.json
+++ b/lib/engines/hcktest/drivers/Balloon.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/NetKVM.json
+++ b/lib/engines/hcktest/drivers/NetKVM.json
@@ -24,7 +24,6 @@
     "PrivateCloudSimulator - Device.Network.LAN.10GbOrGreater",
     "Run RSC Tests",
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/alinvme.json
+++ b/lib/engines/hcktest/drivers/alinvme.json
@@ -39,9 +39,6 @@
         }
       ]
     }
-  ],
-  "reject_test_names": [
-    "Hardware-enforced Stack Protection Compatibility Test"
   ]
 }
 

--- a/lib/engines/hcktest/drivers/fwcfg64.json
+++ b/lib/engines/hcktest/drivers/fwcfg64.json
@@ -4,8 +4,5 @@
   "inf": "fwcfg.inf",
   "install_method": "PNP",
   "type": 0,
-  "support": false,
-  "reject_test_names": [
-    "Hardware-enforced Stack Protection Compatibility Test"
-  ]
+  "support": false
 }

--- a/lib/engines/hcktest/drivers/igb.json
+++ b/lib/engines/hcktest/drivers/igb.json
@@ -19,7 +19,6 @@
   ],
   "reject_test_names": [
     "NDISTest 6.5 - [2 Machine] - VMQReceiveQueueStateChecking",
-    "NDISTest 6.5 - [2 Machine] - VMQPowerManagement",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "NDISTest 6.5 - [2 Machine] - VMQPowerManagement"
   ]
 }

--- a/lib/engines/hcktest/drivers/ivshmem.json
+++ b/lib/engines/hcktest/drivers/ivshmem.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/ovpn-dco-win.json
+++ b/lib/engines/hcktest/drivers/ovpn-dco-win.json
@@ -8,7 +8,6 @@
   "type": 0,
   "support": false,
   "reject_test_names": [
-    "Static Tools Logo Test",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "Static Tools Logo Test"
   ]
 }

--- a/lib/engines/hcktest/drivers/pvpanic.json
+++ b/lib/engines/hcktest/drivers/pvpanic.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/viofs.json
+++ b/lib/engines/hcktest/drivers/viofs.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/viogpu.json
+++ b/lib/engines/hcktest/drivers/viogpu.json
@@ -14,7 +14,6 @@
     "Test for EDID Requirements (Manual)",
     "Multimon minimum resolution check - Multihead",
     "WDDM HPD Notification Test (Manual)",
-    "Check Resolution for Dualview (WoW64) - multihead",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "Check Resolution for Dualview (WoW64) - multihead"
   ]
 }

--- a/lib/engines/hcktest/drivers/vioinput.json
+++ b/lib/engines/hcktest/drivers/vioinput.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/viomem.json
+++ b/lib/engines/hcktest/drivers/viomem.json
@@ -4,8 +4,5 @@
   "inf": "viomem.inf",
   "install_method": "PNP",
   "type": 0,
-  "support": false,
-  "reject_test_names": [
-    "Hardware-enforced Stack Protection Compatibility Test"
-  ]
+  "support": false
 }

--- a/lib/engines/hcktest/drivers/viorng.json
+++ b/lib/engines/hcktest/drivers/viorng.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/vioscsi.json
+++ b/lib/engines/hcktest/drivers/vioscsi.json
@@ -43,7 +43,6 @@
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
     "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "DF - Reboot Restart with IO During (Reliability)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Reboot Restart with IO During (Reliability)"
   ]
 }

--- a/lib/engines/hcktest/drivers/vioserial.json
+++ b/lib/engines/hcktest/drivers/vioserial.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/viosock.json
+++ b/lib/engines/hcktest/drivers/viosock.json
@@ -7,7 +7,6 @@
   "support": false,
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/drivers/viostor.json
+++ b/lib/engines/hcktest/drivers/viostor.json
@@ -46,7 +46,6 @@
     "Thin Provisioning SCSI Compliance Test (LOGO)",
     "Thin Provisioning Performance Test - RAW Disk (LOGO)",
     "Thin Provisioning Performance Test - NTFS (LOGO)",
-    "Thin Provisioning Threshold and Resource Exhaustion Test (LOGO)",
-    "Hardware-enforced Stack Protection Compatibility Test"
+    "Thin Provisioning Threshold and Resource Exhaustion Test (LOGO)"
   ]
 }

--- a/lib/engines/hcktest/hcktest.json
+++ b/lib/engines/hcktest/hcktest.json
@@ -46,6 +46,32 @@
           "value": "C:\\Windows\\mib.bin"
         }
       ]
+    },
+    {
+      "tests": ["Hardware-enforced Stack Protection Compatibility Test"],
+      "pre_test_commands": [
+        {
+          "desc": "Upload HSP watcher script",
+          "files_action": [
+            {
+              "local_path": "lib/engines/hcktest/scripts/autoit/hsp_watcher.au3",
+              "remote_path": "C:\\UIAgent\\autoit\\hsp_watcher.au3",
+              "direction": "local-to-remote"
+            }
+          ]
+        },
+        {
+          "desc": "Set HSP watcher to start on any user logon and reboot to activate",
+          "guest_run": "New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'AutoHCK_UIWatcher' -Value '\"C:\\Program Files (x86)\\AutoIt3\\AutoIt3.exe\" \"C:\\UIAgent\\autoit\\hsp_watcher.au3\"' -PropertyType String -Force",
+          "guest_reboot": true
+        }
+      ],
+      "post_test_commands": [
+        {
+          "desc": "Stop and remove HSP watcher",
+          "guest_run": "Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'AutoHCK_UIWatcher' -ErrorAction SilentlyContinue; Stop-Process -Name AutoIt3 -Force -ErrorAction SilentlyContinue; exit 0"
+        }
+      ]
     }
   ]
 }

--- a/lib/engines/hcktest/scripts/autoit/hsp_watcher.au3
+++ b/lib/engines/hcktest/scripts/autoit/hsp_watcher.au3
@@ -1,0 +1,52 @@
+#NoTrayIcon
+#include <AutoItConstants.au3>
+
+Opt("WinTitleMatchMode", 2)
+HotKeySet("+{ESC}", "Terminate")
+
+Global $hspDone = False
+Global $ignoredCmds = "|"
+
+ConsoleWrite("[" & @HOUR & ":" & @MIN & ":" & @SEC & "] HSP Watcher Started..." & @CRLF)
+
+While 1
+    If Not $hspDone And WinExists("C:\Windows\SYSTEM32\cmd.exe") Then
+        Local $hWnd = WinGetHandle("C:\Windows\SYSTEM32\cmd.exe")
+
+        If Not StringInStr($ignoredCmds, "|" & $hWnd & "|") Then
+            WinActivate($hWnd)
+            WinWaitActive($hWnd, "", 2)
+
+            Local $bakClip = ClipGet()
+            ClipPut("")
+
+            Send("^a")
+            Sleep(100)
+            Send("{ENTER}")
+            Sleep(200)
+
+            Local $winText = ClipGet()
+            ClipPut($bakClip)
+
+            If StringInStr($winText, "Hardware-enforced") Then
+                ConsoleWrite("[" & @HOUR & ":" & @MIN & ":" & @SEC & "] Confirmed HSP test window, sending Y..." & @CRLF)
+                Send("{ESC}")
+                Sleep(100)
+                Send("Y")
+                Sleep(200)
+                Send("{ENTER}")
+                $hspDone = True
+                Sleep(5000)
+            Else
+                Send("{ESC}")
+                $ignoredCmds &= $hWnd & "|"
+            EndIf
+        EndIf
+    EndIf
+
+    Sleep(200)
+WEnd
+
+Func Terminate()
+    Exit
+EndFunc

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -205,6 +205,11 @@ module AutoHCK
 
       run_command_on_client(@client, command.guest_run, command.desc, replacement)
       run_command_on_client(@support, command.guest_run, command.desc, replacement) unless @support.nil?
+
+      return unless command.guest_reboot
+
+      @logger.info("Rebooting client #{@client.name} after command (#{command.desc})")
+      @tools.restart_machine(@client.name)
     end
 
     def run_host_test_command(command)


### PR DESCRIPTION
Use an AutoIt watcher script to automate the HSP test across all
drivers that previously rejected it. An HKLM Run key launches the
watcher in the interactive session, with a reboot to activate it.

- Add HSP tests_config to hcktest.json with pre/post commands to
  upload, register, and clean up the AutoIt watcher
- Add guest_reboot support to pre_test_commands in tests.rb
- Add autoit to HLK2022.json extra_software

Depends on:
- AutoIt extra software: [https://github.com/HCK-CI/extra-software/pull/24]