### PR TITLE
VIRTWINKVM-2159: Add image metadata JSON to record image's info

### DIFF
--- a/lib/all.rb
+++ b/lib/all.rb
@@ -17,6 +17,7 @@ module AutoHCK
   require 'shellwords'
   require 'socket'
   require 'tempfile'
+  require 'time'
   require 'uri'
   require 'yaml'
   require 'zip'

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -106,10 +106,10 @@ module AutoHCK
     end
 
     def prepare_extra_sw
-      extra_software = [*@kit_info.extra_software, *@project.engine_platform['extra_software']]
+      @extra_software = [*@kit_info.extra_software, *@project.engine_platform['extra_software']]
 
       @project.extra_sw_manager.prepare_software_packages(
-        extra_software, @project.engine_platform['kit'], ENGINE_MODE
+        @extra_software, @project.engine_platform['kit'], ENGINE_MODE
       )
 
       @project.extra_sw_manager.copy_to_setup_scripts(@workspace_hlk_setup_scripts_path)
@@ -470,6 +470,41 @@ module AutoHCK
       !@project.options.install.skip_client
     end
 
+    def image_metadata(iso_info, type)
+      {
+        date: Time.now.utc.iso8601,
+        iso_name: iso_info['path'],
+        windows_image_names: iso_info.dig(type, 'windows_image_names'),
+        autohck_version: AutoHCK::VERSION,
+        extra_software: @extra_software
+      }
+    end
+
+    def generate_client_image_metadata(client_name)
+      @logger.debug("Generating metadata for client image: #{client_name}")
+
+      metadata = image_metadata(@client_iso_info, 'client')
+
+      @project.setup_manager.save_client_image_metadata(client_name, metadata)
+    end
+
+    def generate_studio_image_metadata
+      @logger.debug('Generating studio image metadata')
+
+      metadata = image_metadata(@studio_iso_info, 'studio')
+
+      @project.setup_manager.save_studio_image_metadata(metadata)
+    end
+
+    def generate_images_metadata(studio:, client:)
+      if client
+        @clients_name.each do |client_name|
+          generate_client_image_metadata(client_name)
+        end
+      end
+      generate_studio_image_metadata if studio
+    end
+
     def run
       @logger.debug('HCKInstall: run')
 
@@ -482,6 +517,8 @@ module AutoHCK
         run_first(studio:, client:)
         run_second(client:)
       end
+
+      generate_images_metadata(studio:, client:)
     end
   end
 end

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -69,12 +69,20 @@ module AutoHCK
       @logger.info('Image creating is currently not supported for physical machines')
     end
 
+    def save_studio_image_metadata(_metadata)
+      @logger.info('Image metadata saving is currently not supported for physical machines')
+    end
+
     def check_client_image_exist(_name)
       @logger.info('Image checking is currently not supported for physical machines')
     end
 
     def create_client_image(_name)
       @logger.info('Image creating is currently not supported for physical machines')
+    end
+
+    def save_client_image_metadata(_name, _metadata)
+      @logger.info('Image metadata saving is currently not supported for physical machines')
     end
 
     def run_studio(*)

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -671,6 +671,10 @@ module AutoHCK
       @sm.create_boot_image
     end
 
+    def save_image_metadata(metadata)
+      @sm.save_image_metadata(metadata)
+    end
+
     def delete_snapshot
       @sm.delete_boot_snapshot
     end

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -186,12 +186,20 @@ module AutoHCK
       @studio_vm.create_image
     end
 
+    def save_studio_image_metadata(metadata)
+      @studio_vm.save_image_metadata(metadata)
+    end
+
     def check_client_image_exist(name)
       @clients_vm[name].check_image_exist
     end
 
     def create_client_image(name)
       @clients_vm[name].create_image
+    end
+
+    def save_client_image_metadata(name, metadata)
+      @clients_vm[name].save_image_metadata(metadata)
     end
 
     def studio_option_config(option)

--- a/lib/setupmanagers/qemuhck/storage_manager.rb
+++ b/lib/setupmanagers/qemuhck/storage_manager.rb
@@ -52,6 +52,12 @@ module AutoHCK
         create_image(@boot_image_path, 150, IMAGE_FORMAT)
       end
 
+      def save_image_metadata(metadata)
+        metadata[:checksum] = Digest::SHA256.file(@boot_image_path).hexdigest
+
+        File.write("#{@boot_image_path}.json", metadata.to_json)
+      end
+
       def create_test_image
         if File.exist?(@fs_test_image)
           @logger.info("Coping test image for CL#{@client_id}")


### PR DESCRIPTION
Write a JSON file alongside each image (studio and clients) containing: installation date, ISO name, Windows image name, AutoHCK version, extra software list, and SHA256 checksum.