### PR TITLE
VIRTWINKVM-2163: Add --query option to get list of images for platform

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -99,6 +99,8 @@ module AutoHCK
     prop :extensions, T::Array[String], default: []
     prop :net_test_speed, Integer, default: 10_000
     prop :auto_retry_failed_tests, Integer, default: 0
+    prop :query, T.nilable(String)
+    prop :query_output_file, T.nilable(String)
 
     def create_parser
       OptionParser.new do |parser|
@@ -236,6 +238,15 @@ module AutoHCK
                 '  0 - do not retry failed tests;',
                 '  N - retry failed tests up to N times.',
                 &method(:auto_retry_failed_tests=))
+
+      parser.on('--query <query>', String,
+                'Run a query and exit without starting a test session.',
+                'Supported queries: images-names',
+                &method(:query=))
+
+      parser.on('--query-output-file <path>', String,
+                'Write query output to the specified file in addition to the log',
+                &method(:query_output_file=))
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -30,8 +30,41 @@ module AutoHCK
       scope << self
     end
 
+    def images_names_query_output
+      raise(AutoHCKError, "Platform #{@options.test.platform} not found") if @engine_platform.nil?
+
+      lines = ["Studio image: #{@engine_platform['st_image']}"]
+      @engine_platform['clients'].each_value do |client|
+        lines << "Client #{client['name']}: #{client['image']}"
+      end
+      lines.join("\n")
+    end
+
+    def write_query_output_file(output)
+      File.write(@options.test.query_output_file, "#{output}\n")
+    rescue SystemCallError => e
+      raise(AutoHCKError, "Failed to write query output to #{@options.test.query_output_file}: #{e.message}")
+    end
+
+    def handle_query(query)
+      case query
+      when 'images-names'
+        output = images_names_query_output
+        @logger.info(output)
+        write_query_output_file(output) unless @options.test.query_output_file.nil?
+      else
+        raise(AutoHCKError, "Unknown query: #{query}")
+      end
+    end
+
     def prepare
       @extra_sw_manager = ExtraSoftwareManager.new(self)
+
+      query = @options.test.query
+      unless query.nil?
+        handle_query(query)
+        return false
+      end
 
       @engine = @engine_type.new(self)
       Sentry.set_tags('autohck.tag': @engine_tag)
@@ -165,7 +198,13 @@ module AutoHCK
       @github.handle_cancel
     end
 
+    def query_mode?
+      @options.mode == 'test' && !@options.test.query.nil?
+    end
+
     def init_workspace
+      return if query_mode?
+
       unless @options.common.workspace_path.nil?
         @workspace_path = @options.common.workspace_path
         return
@@ -210,6 +249,8 @@ module AutoHCK
     end
 
     def close
+      return if query_mode?
+
       @logger.debug('Closing AutoHCK project')
       generate_junit
 


### PR DESCRIPTION
Add --query=images-names and --query-output-file options. Output the studio and client image names for the given platform to the log and optionally to a file, then exit without starting a test session or creating a workspace directory.