### PR TITLE
QemuHCK: Use host as a default CPU (breaking changes)

### DIFF
--- a/lib/setupmanagers/qemuhck/qemu_machine.json
+++ b/lib/setupmanagers/qemuhck/qemu_machine.json
@@ -13,9 +13,9 @@
   "share_on_host_net": "192.168.101",
   "platforms_defaults": {
     "cpu": "qemu64",
+    "cpu_options": "+x2apic,+fsgsbase,model=13",
     "cpu_count": 2,
     "memory_gb": 4,
-    "cpu_model": 13,
     "world_net_device": "e1000e",
     "ctrl_net_device": "e1000e",
     "debug_net_device": "e1000e",

--- a/lib/setupmanagers/qemuhck/qemu_machine.json
+++ b/lib/setupmanagers/qemuhck/qemu_machine.json
@@ -12,8 +12,8 @@
   "share_on_host_net__comment": "The =FIRST THREE= octets of the share IP",
   "share_on_host_net": "192.168.101",
   "platforms_defaults": {
-    "cpu": "qemu64",
-    "cpu_options": "+x2apic,+fsgsbase,model=13",
+    "cpu": "host",
+    "cpu_options": "",
     "cpu_count": 2,
     "memory_gb": 4,
     "world_net_device": "e1000e",

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -187,7 +187,7 @@ module AutoHCK
       @device_commands = []
       @machine_options = %w[@machine_name@]
       @device_extra_param = []
-      @cpu_options = %w[@cpu@ +x2apic +fsgsbase model=@cpu_model@]
+      @cpu_options = %w[@cpu@]
       @drive_cache_options = []
       @define_variables = {}
       @run_opts = {}
@@ -375,8 +375,8 @@ module AutoHCK
                            '@source@' => Dir.pwd,
                            '@workspace@' => @workspace_path,
                            '@cpu@' => option_config('cpu'),
+                           '@cpu_options@' => option_config('cpu_options'),
                            '@cpu_count@' => option_config('cpu_count'),
-                           '@cpu_model@' => option_config('cpu_model'),
                            '@vnc_id@' => @vnc_id,
                            '@vnc_port@' => @vnc_port,
                            '@qemu_monitor_port@' => @monitor_port


### PR DESCRIPTION
@YanVugenfirer Do we want to drop "host" from platform names, as we did before for "uefi"?