### PR TITLE
VIRTWINKVM-2167: add errata support for known HLK test failures

### DIFF
--- a/lib/engines/hcktest/drivers/vioscsi.json
+++ b/lib/engines/hcktest/drivers/vioscsi.json
@@ -18,6 +18,13 @@
   "tests_config": [
     {
       "tests": [
+        "Flush Test"
+      ],
+      "kits": ["HLK2022"],
+      "errata": "Flush Test - known HLK failure on Win2022"
+    },
+    {
+      "tests": [
         ".*"
       ],
       "pre_test_commands": [

--- a/lib/engines/hcktest/drivers/viostor.json
+++ b/lib/engines/hcktest/drivers/viostor.json
@@ -18,6 +18,13 @@
   "tests_config": [
     {
       "tests": [
+        "Flush Test"
+      ],
+      "kits": ["HLK2022"],
+      "errata": "Flush Test - known HLK failure on Win2022"
+    },
+    {
+      "tests": [
         ".*"
       ],
       "pre_test_commands": [

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -187,6 +187,10 @@ module AutoHCK
       select_test_config(test_name, :skip_retry).any? { _1 == true }
     end
 
+    def test_errata(test_name)
+      select_test_config(test_name, :errata).compact.first
+    end
+
     def run_command_on_client(client, command, desc, guest_reboot, replacement)
       cl_name = client.name
       @logger.info("Running command (#{desc}) on client #{cl_name}")
@@ -547,6 +551,14 @@ module AutoHCK
 
       test.finished_at = DateTime.now
       test.last_result = test_result
+
+      return unless test.status == Models::HLK::TestResultStatus::Failed
+
+      errata = test_errata(test.name)
+      return unless errata
+
+      @logger.info("Test '#{test.name}' failed but has manual errata: #{errata}")
+      test.errata = errata
     end
 
     sig { params(result: T::Hash[String, T.untyped]).returns(Models::HLK::Test) }

--- a/lib/junit.rb
+++ b/lib/junit.rb
@@ -74,7 +74,7 @@ module AutoHCK
     end
 
     def junit_failed_test_steps_count
-      engine_test_steps.count { _1.status == Models::HLK::TestResultStatus::Failed }
+      engine_test_steps.count { _1.status == Models::HLK::TestResultStatus::Failed && _1.errata.nil? }
     end
 
     def junit_suite_tests_count

--- a/lib/models/hlk.rb
+++ b/lib/models/hlk.rb
@@ -85,6 +85,7 @@ module AutoHCK
         prop :last_result, T.nilable(T::Hash[String, T.untyped])
         prop :is_skipped, T::Boolean, default: false
         prop :retried_times, Integer, default: 0
+        prop :errata, T.nilable(String), default: nil
 
         sig { params(hck_test: Test).void }
         def update_from_hck(hck_test)

--- a/lib/models/test_config.rb
+++ b/lib/models/test_config.rb
@@ -20,6 +20,7 @@ module AutoHCK
       const :kits, T::Array[String], default: []
       const :parameters, T::Array[Parameter], default: []
       const :skip_retry, T::Boolean, default: false
+      const :errata, T.nilable(String), default: nil
       const :pre_test_commands, T::Array[CommandInfo], default: []
       const :post_test_commands, T::Array[CommandInfo], default: []
     end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -289,6 +289,7 @@ module AutoHCK
 
       failed = engine.test_steps.any? do |step|
         !step.is_skipped &&
+          step.errata.nil? &&
           step.status == Models::HLK::TestResultStatus::Failed &&
           step.executionstate == Models::HLK::ExecutionState::NotRunning
       end

--- a/lib/result_report.rb
+++ b/lib/result_report.rb
@@ -40,12 +40,18 @@ module AutoHCK
 
     def test_stats(test_steps)
       run_steps = test_steps.reject(&:is_skipped)
+      passed_with_errata = run_steps.count do |t|
+        t.errata &&
+          t.executionstate == Models::HLK::ExecutionState::NotRunning
+      end
       passed = run_steps.count do |t|
         t.status == Models::HLK::TestResultStatus::Passed &&
+          t.errata.nil? &&
           t.executionstate == Models::HLK::ExecutionState::NotRunning
       end
       failed = run_steps.count do |t|
         t.status == Models::HLK::TestResultStatus::Failed &&
+          t.errata.nil? &&
           t.executionstate == Models::HLK::ExecutionState::NotRunning
       end
       total = run_steps.count
@@ -53,8 +59,9 @@ module AutoHCK
 
       {
         'passed' => passed,
+        'passed_with_errata' => passed_with_errata,
         'failed' => failed,
-        'inqueue' => total - passed - failed,
+        'inqueue' => total - passed - passed_with_errata - failed,
         'skipped' => skipped
       }
     end

--- a/lib/templates/junit.xml.erb
+++ b/lib/templates/junit.xml.erb
@@ -28,7 +28,9 @@
                 <% unless test_step.last_result.nil? %>
                     <system-out><%= JSON.pretty_generate(test_step.last_result) %></system-out>
                 <% end %>
-                <% if test_step.status == Models::HLK::TestResultStatus::Failed %>
+                <% if test_step.errata %>
+                    <system-out>Passed with errata: <%= test_step.errata %></system-out>
+                <% elsif test_step.status == Models::HLK::TestResultStatus::Failed %>
                     <failure />
                 <% elsif test_step.is_skipped %>
                     <skipped />

--- a/lib/templates/report.html.erb
+++ b/lib/templates/report.html.erb
@@ -79,6 +79,8 @@
                         <% row += 1 %>
                         <% if test.is_skipped %>
                         <tr class="table-warning">
+                        <% elsif test.errata %>
+                        <tr class="table-info">
                         <% elsif test.status == AutoHCK::Models::HLK::TestResultStatus::Passed %>
                         <tr class="table-success">
                         <% elsif test.status == AutoHCK::Models::HLK::TestResultStatus::Failed %>
@@ -93,7 +95,13 @@
                                 <% unless test.url.nil? %></a><% end %>
                             </td>
                             <td><%= test.estimatedruntime %></td>
-                            <td><%= test.is_skipped ? 'Skipped' : test.status.to_s %></td>
+                            <td>
+                                <% if test.errata %>
+                                    Passed (with errata)
+                                <% else %>
+                                    <%= test.is_skipped ? 'Skipped' : test.status.to_s %>
+                                <% end %>
+                            </td>
                         </tr>
                     <% end %>
                 </tbody>
@@ -118,6 +126,7 @@
                     <% end %>
                     'Failed',
                     'Passed',
+                    'Passed (with errata)',
                     'NotRun'
                 ],
                 datasets: [{
@@ -127,6 +136,7 @@
                         <% end %>
                         <%= test_stats['failed'] %>,
                         <%= test_stats['passed'] %>,
+                        <%= test_stats['passed_with_errata'] %>,
                         <%= test_stats['inqueue'] %>
                     ],
                     backgroundColor: [
@@ -135,6 +145,7 @@
                         <% end %>
                         '#DC3545',
                         '#28A745',
+                        '#0DCAF0',
                         '#6C757D',
                     ],
                     borderWidth: 1


### PR DESCRIPTION
Allow tests_config entries to specify an errata reason string. When a test fails and matches an errata config, it is treated as "Passed (with errata)" instead of a failure.

- Add Flush Test errata entry for viostor and vioscsi on HLK2022