### PR TITLE
viostor: Clear disk before each test

### DIFF
--- a/lib/engines/hcktest/drivers/viostor.json
+++ b/lib/engines/hcktest/drivers/viostor.json
@@ -22,6 +22,11 @@
       ],
       "pre_test_commands": [
         {
+          "desc": "Clear Disk",
+          "comment": "On Server 2019, disk contains 2 partitions after the Flush Test. We need to clear the disk to avoid the next command failure.",
+          "guest_run": "Clear-Disk -Number 1 -Confirm:$false -RemoveData -ErrorAction SilentlyContinue; exit 0"
+        },
+        {
           "desc": "Initialize Disk",
           "guest_run": "Initialize-Disk -Number 1 -PartitionStyle GPT -ErrorAction SilentlyContinue; exit 0"
         },


### PR DESCRIPTION
@zjmletang Did you see the similar issue with NVME on Server 2019? 
We catch it only with viostor, for some reason.