### PR TITLE
RHEL-175830: add TPM state support for platform

### DIFF
--- a/lib/engines/hcktest/platforms/Win11_22H2x64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_22H2x64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win11_22H2x64",
   "kit": "HLK11_22H2",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "clients_options": {
     "viommu_state": true,
     "enlightenments_state": true

--- a/lib/engines/hcktest/platforms/Win11_23H2x64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_23H2x64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win11_23H2x64",
   "kit": "HLK11_23H2",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "clients_options": {
     "viommu_state": true,
     "enlightenments_state": true

--- a/lib/engines/hcktest/platforms/Win11_24H2x64_host.json
+++ b/lib/engines/hcktest/platforms/Win11_24H2x64_host.json
@@ -4,6 +4,7 @@
   "kit": "HLK11_24H2",
   "setupmanager": "qemuhck",
   "fw_type": "uefi",
+  "tpm_state": true,
   "cpu": "host",
   "st_image": "HLK11_24H2.qcow2",
   "clients": {

--- a/lib/engines/hcktest/platforms/Win11_24H2x64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_24H2x64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win11_24H2x64",
   "kit": "HLK11_24H2",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "cpu": "host",
   "st_image": "HLK11_24H2.qcow2",
   "clients_options": {

--- a/lib/engines/hcktest/platforms/Win11_25H2x64_host.json
+++ b/lib/engines/hcktest/platforms/Win11_25H2x64_host.json
@@ -4,6 +4,7 @@
   "kit": "HLK11_25H2",
   "setupmanager": "qemuhck",
   "fw_type": "uefi",
+  "tpm_state": true,
   "cpu": "host",
   "st_image": "HLK11_25H2.qcow2",
   "clients": {

--- a/lib/engines/hcktest/platforms/Win11_25H2x64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_25H2x64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win11_25H2x64",
   "kit": "HLK11_25H2",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "cpu": "host",
   "st_image": "HLK11_25H2.qcow2",
   "clients_options": {

--- a/lib/engines/hcktest/platforms/Win11nextx64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11nextx64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win11nextx64",
   "kit": "HLK11_next",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "clients_options": {
     "viommu_state": true,
     "enlightenments_state": true

--- a/lib/engines/hcktest/platforms/Win2022x64.json
+++ b/lib/engines/hcktest/platforms/Win2022x64.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2022x64",
   "kit": "HLK2022",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "st_image": "HLK2022.qcow2",
   "clients": {
     "c1": {

--- a/lib/engines/hcktest/platforms/Win2022x64_gui.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_gui.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2022x64-gui",
   "kit": "HLK2022",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "st_image": "HLK2022.qcow2",
   "clients": {
     "c1": {

--- a/lib/engines/hcktest/platforms/Win2022x64_host.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_host.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2022x64",
   "kit": "HLK2022",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "st_image": "HLK2022.qcow2",
   "cpu": "host",
   "clients": {

--- a/lib/engines/hcktest/platforms/Win2022x64_host_gui.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_host_gui.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2022x64-gui",
   "kit": "HLK2022",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "st_image": "HLK2022.qcow2",
   "cpu": "host",
   "clients": {

--- a/lib/engines/hcktest/platforms/Win2022x64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2022x64",
   "kit": "HLK2022",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "clients_options": {
     "viommu_state": true,
     "enlightenments_state": true

--- a/lib/engines/hcktest/platforms/Win2025nextx64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2025nextx64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2025nextx64",
   "kit": "HLK2025_next",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "clients_options": {
     "viommu_state": true,
     "enlightenments_state": true

--- a/lib/engines/hcktest/platforms/Win2025x64_host.json
+++ b/lib/engines/hcktest/platforms/Win2025x64_host.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2025x64",
   "kit": "HLK2025",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "enlightenments_state": true,
   "cpu": "host",
   "st_image": "HLK2025.qcow2",

--- a/lib/engines/hcktest/platforms/Win2025x64_host_gui.json
+++ b/lib/engines/hcktest/platforms/Win2025x64_host_gui.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2025x64-gui",
   "kit": "HLK2025",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "enlightenments_state": true,
   "cpu": "host",
   "st_image": "HLK2025.qcow2",

--- a/lib/engines/hcktest/platforms/Win2025x64_host_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2025x64_host_viommu.json
@@ -3,6 +3,7 @@
   "client_iso": "Win2025x64",
   "kit": "HLK2025",
   "setupmanager": "qemuhck",
+  "tpm_state": true,
   "clients_options": {
     "viommu_state": true,
     "enlightenments_state": true

--- a/lib/setupmanagers/qemuhck/qemu_machine.json
+++ b/lib/setupmanagers/qemuhck/qemu_machine.json
@@ -28,6 +28,7 @@
     "enlightenments_state": false,
     "vhost_state": true,
     "viommu_state": false,
-    "drive_unsafe_cache_state": false
+    "drive_unsafe_cache_state": false,
+    "tpm_state": false
   }
 }

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -14,7 +14,7 @@ module AutoHCK
 
     QEMUHCK_INFO_LOG_FILE = 'qemuhck.txt'
     OPT_NAMES = %w[viommu_state s3_state s4_state enlightenments_state vhost_state machine_type fw_type cpu
-                   ctrl_net_device vbs_state].freeze
+                   ctrl_net_device vbs_state tpm_state].freeze
 
     def initialize(project)
       initialize_project project

--- a/lib/setupmanagers/qemuhck/states.json
+++ b/lib/setupmanagers/qemuhck/states.json
@@ -59,8 +59,8 @@
             ]
         }
     },
-    "fw_type": {
-        "uefi": {
+    "tpm_state": {
+        "true": {
             "devices_list": [
                 "tpm-tis"
             ]


### PR DESCRIPTION
qemuhck: add TPM state support

Add tpm_state option to OPT_NAMES, set its default to false in
qemu_machine.json, and map tpm_state=true to the tpm-tis device
in states.json (replacing the fw_type/uefi approach).
Now TPM is a platform requirement, not a firmware one.