### PR TITLE
VIRTWINKVM-2173: [viogpu] Handle multimon tests with AutoIt watcher

### DIFF
--- a/lib/engines/hcktest/drivers/viogpu.json
+++ b/lib/engines/hcktest/drivers/viogpu.json
@@ -64,12 +64,39 @@
           "guest_run": "Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'AutoHCK_HPDWatcher' -ErrorAction SilentlyContinue; Stop-Process -Name AutoIt3 -Force -ErrorAction SilentlyContinue; exit 0"
         }
       ]
+    },
+    {
+      "tests": [
+        "Multimon minimum resolution check - Multihead",
+        "Check Resolution for Dualview \\(WoW64\\) - multihead"
+      ],
+      "pre_test_commands": [
+        {
+          "desc": "Upload Multimon watcher script",
+          "files_action": [
+            {
+              "local_path": "lib/engines/hcktest/scripts/autoit/multimon_watcher.au3",
+              "remote_path": "C:\\UIAgent\\autoit\\multimon_watcher.au3",
+              "direction": "local-to-remote"
+            }
+          ]
+        },
+        {
+          "desc": "Set Multimon watcher to start on any user logon and reboot to activate",
+          "guest_run": "New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'AutoHCK_MultimonWatcher' -Value '\"C:\\Program Files (x86)\\AutoIt3\\AutoIt3.exe\" \"C:\\UIAgent\\autoit\\multimon_watcher.au3\"' -PropertyType String -Force",
+          "guest_reboot": true
+        }
+      ],
+      "post_test_commands": [
+        {
+          "desc": "Stop and remove Multimon watcher",
+          "guest_run": "Remove-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'AutoHCK_MultimonWatcher' -ErrorAction SilentlyContinue; Stop-Process -Name AutoIt3 -Force -ErrorAction SilentlyContinue; exit 0"
+        }
+      ]
     }
   ],
   "reject_test_names": [
     "DF - Embedded Signature Verification Test (Certification)",
-    "DF - Embedded Signature Verification Test (Tuning and Validation)",
-    "Multimon minimum resolution check - Multihead",
-    "Check Resolution for Dualview (WoW64) - multihead"
+    "DF - Embedded Signature Verification Test (Tuning and Validation)"
   ]
 }

--- a/lib/engines/hcktest/scripts/autoit/multimon_watcher.au3
+++ b/lib/engines/hcktest/scripts/autoit/multimon_watcher.au3
@@ -1,0 +1,26 @@
+#NoTrayIcon
+#include <AutoItConstants.au3>
+
+Opt("WinTitleMatchMode", 2)
+HotKeySet("+{ESC}", "Terminate")
+
+ConsoleWrite("[" & @HOUR & ":" & @MIN & ":" & @SEC & "] Multimon watcher started..." & @CRLF)
+
+While 1
+    ; --- Multimon minimum resolution check / Check Resolution for Dualview ---
+    If WinExists("VerifyMultimon", "Please configure this system for multimon") Then
+        ConsoleWrite("[" & @HOUR & ":" & @MIN & ":" & @SEC & "] VerifyMultimon window detected, clicking Continue..." & @CRLF)
+        WinActivate("VerifyMultimon")
+        WinWaitActive("VerifyMultimon", "", 2)
+        If Not ControlClick("VerifyMultimon", "", "[TEXT:Continue]") Then
+            ControlClick("VerifyMultimon", "", "[CLASS:Button; INSTANCE:3]")
+        EndIf
+        WinWaitClose("VerifyMultimon", "", 3)
+    EndIf
+
+    Sleep(200)
+WEnd
+
+Func Terminate()
+    Exit
+EndFunc


### PR DESCRIPTION
Add multimon_watcher.au3 to automatically click "Continue" in the VerifyMultimon dialog during "Multimon minimum resolution check - Multihead" and "Check Resolution for Dualview (WoW64) - multihead" tests.