### PR TITLE
Initial support for 32bit platforms

### DIFF
--- a/lib/engines/hckinstall/answer-files/autounattend.xml.bios.in
+++ b/lib/engines/hckinstall/answer-files/autounattend.xml.bios.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
                 <WillShowUI>OnError</WillShowUI>
@@ -12,14 +12,14 @@
             <UserLocale>en-US</UserLocale>
             <InputLocale>0409:00000409</InputLocale>
         </component>
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DriverPaths>
                 <PathAndCredentials wcm:keyValue="1" wcm:action="add">
                     <Path>d:\drivers\</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>
-        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DiskConfiguration>
                 <Disk wcm:action="add">
                     <DiskID>0</DiskID>

--- a/lib/engines/hckinstall/answer-files/autounattend.xml.uefi.in
+++ b/lib/engines/hckinstall/answer-files/autounattend.xml.uefi.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
                 <WillShowUI>OnError</WillShowUI>
@@ -12,14 +12,14 @@
             <UserLocale>en-US</UserLocale>
             <InputLocale>0409:00000409</InputLocale>
         </component>
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DriverPaths>
                 <PathAndCredentials wcm:keyValue="1" wcm:action="add">
                     <Path>d:\drivers\</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>
-        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DiskConfiguration>
                 <Disk wcm:action="add">
                     <DiskID>0</DiskID>

--- a/lib/engines/hckinstall/answer-files/unattend.xml.in
+++ b/lib/engines/hckinstall/answer-files/unattend.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="oobeSystem">
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
                     <Value>@DEFAULT_PASSWORD@</Value>
@@ -34,7 +34,7 @@
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>
-        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>0409:00000409</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
@@ -43,7 +43,7 @@
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="@PROCESSOR_ARCHITECTURE@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <CopyProfile>true</CopyProfile>
         </component>
     </settings>

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -91,17 +91,28 @@ module AutoHCK
       res || raise(InvalidConfigFile, "Kit studio platform for kit #{kit} does not exist")
     end
 
+    def init_clients_iso_info
+      @client_iso_infos = {}
+      @setup_client_isos = {}
+      fallback_iso = @project.engine_platform['client_iso']
+
+      @project.engine_platform['clients'].each_value do |client|
+        iso_name = client['client_iso'] || fallback_iso
+        client_name = client['name']
+
+        @logger.info("Client ISO name for #{client_name} is #{iso_name}")
+        @client_iso_infos[client_name] = read_iso(iso_name)
+        @setup_client_isos[client_name] = Pathname.new(@project.workspace_path).join("setup-client-#{client_name}.iso")
+      end
+    end
+
     def init_iso_info
       studio_iso = studio_iso_name(@project.engine_platform['kit'])
       @logger.info("Studio ISO name is #{studio_iso}")
       @studio_iso_info = read_iso(studio_iso)
-
-      client_iso = @project.engine_platform['client_iso']
-      @logger.info("Client ISO name is #{client_iso}")
-      @client_iso_info = read_iso(client_iso)
-
       @setup_studio_iso = Pathname.new(@project.workspace_path).join('setup-studio.iso')
-      @setup_client_iso = Pathname.new(@project.workspace_path).join('setup-client.iso')
+
+      init_clients_iso_info
     end
 
     def init_class_variables
@@ -128,16 +139,18 @@ module AutoHCK
         raise(InvalidPathError, "Studio ISO path #{studio_iso_full_path} is not valid")
       end
 
-      client_iso_full_path = @iso_path.join(@client_iso_info['path'])
-      return if File.exist?(client_iso_full_path)
+      @client_iso_infos.each do |iso_name, iso_info|
+        client_iso_full_path = @iso_path.join(iso_info['path'])
+        next if File.exist?(client_iso_full_path)
 
-      @logger.fatal("Client ISO path #{client_iso_full_path} is not valid")
-      raise(InvalidPathError, "Client ISO path #{client_iso_full_path} is not valid")
+        @logger.fatal("Client ISO path #{client_iso_full_path} for #{iso_name} is not valid")
+        raise(InvalidPathError, "Client ISO path #{client_iso_full_path} for #{iso_name} is not valid")
+      end
     end
 
     def normalize_paths
       @studio_iso_info['path'].chomp!('/')
-      @client_iso_info['path'].chomp!('/')
+      @client_iso_infos.each_value { |info| info['path'].chomp!('/') }
     end
 
     sig { params(driver: String).returns(Models::Driver) }
@@ -204,8 +217,8 @@ module AutoHCK
       cl_opts = {
         create_snapshot: snapshot,
         attach_iso_list: [
-          @setup_client_iso,
-          @client_iso_info['path']
+          @setup_client_isos[name],
+          @client_iso_infos[name]['path']
         ],
         secure:
       }
@@ -373,8 +386,8 @@ module AutoHCK
       build_answer_file_path(file, disk_config)
     end
 
-    def build_client_answer_file_path(file)
-      fw_type = @project.setup_manager.client_option_config(@clients_name.first, 'fw_type')
+    def build_client_answer_file_path(file, client_name)
+      fw_type = @project.setup_manager.client_option_config(client_name, 'fw_type')
 
       disk_config = load_fw_disk_config(fw_type)
 
@@ -419,13 +432,13 @@ module AutoHCK
                            @workspace_hlk_setup_scripts_path.join('drivers'))
     end
 
-    def create_client_answer_files
-      client = @client_iso_info['client']
+    def create_client_answer_files_for_client(client_name)
+      client = @client_iso_infos[client_name]['client']
       if client.nil?
         @logger.fatal('Client ISO config is invalid, missing "client" section')
         raise(InvalidConfigFile, 'Client ISO config is invalid, missing "client" section')
       end
-      @logger.debug('Creating client answer files')
+      @logger.debug("Creating client answer files for #{client_name}")
 
       product_key = client['product_key']
 
@@ -437,7 +450,7 @@ module AutoHCK
         '@DEFAULT_PASSWORD@' => @project.config['windows_password']
       }
       @answer_files.each do |file|
-        file_gsub(build_client_answer_file_path(file),
+        file_gsub(build_client_answer_file_path(file, client_name),
                   @workspace_hlk_setup_scripts_path.join(file),
                   replacement_list)
       end
@@ -446,13 +459,13 @@ module AutoHCK
     def prepare_client_drives
       @logger.info('HCKInstall: Prepare client drives')
 
-      create_client_answer_files
-
       copy_drivers if @need_copy_drivers
 
-      create_iso(@setup_client_iso, [@workspace_hlk_setup_scripts_path], ['Kits'])
-
-      @clients_name.each { @project.setup_manager.create_client_image(_1) }
+      @clients_name.each do |client_name|
+        create_client_answer_files_for_client(client_name)
+        create_iso(@setup_client_isos[client_name], [@workspace_hlk_setup_scripts_path], ['Kits'])
+        @project.setup_manager.create_client_image(client_name)
+      end
     end
 
     def tag
@@ -488,7 +501,7 @@ module AutoHCK
     def generate_client_image_metadata(client_name)
       @logger.debug("Generating metadata for client image: #{client_name}")
 
-      metadata = image_metadata(@client_iso_info, 'client')
+      metadata = image_metadata(@client_iso_infos[client_name], 'client')
 
       @project.setup_manager.save_client_image_metadata(client_name, metadata)
     end

--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -394,6 +394,11 @@ module AutoHCK
       build_answer_file_path(file, disk_config)
     end
 
+    def client_platform_arch(client_name)
+      client = @project.engine_platform['clients'].values.find { |c| c['name'] == client_name }
+      client&.dig('arch') || @project.engine_platform['client_arch'] || Project::DEFAULT_ARCH
+    end
+
     def create_studio_answer_files
       studio = @studio_iso_info['studio']
       if studio.nil?
@@ -408,7 +413,8 @@ module AutoHCK
         '@PRODUCT_KEY@' => product_key,
         '@PRODUCT_KEY_XML@' => product_key_xml(product_key),
         '@HOST_TYPE@' => 'studio',
-        '@DEFAULT_PASSWORD@' => @project.config['windows_password']
+        '@DEFAULT_PASSWORD@' => @project.config['windows_password'],
+        '@PROCESSOR_ARCHITECTURE@' => Project::DEFAULT_ARCH
       }
       @answer_files.each do |file|
         file_gsub(build_studio_answer_file_path(file),
@@ -447,7 +453,8 @@ module AutoHCK
         '@PRODUCT_KEY@' => product_key,
         '@PRODUCT_KEY_XML@' => product_key_xml(product_key),
         '@HOST_TYPE@' => 'client',
-        '@DEFAULT_PASSWORD@' => @project.config['windows_password']
+        '@DEFAULT_PASSWORD@' => @project.config['windows_password'],
+        '@PROCESSOR_ARCHITECTURE@' => client_platform_arch(client_name)
       }
       @answer_files.each do |file|
         file_gsub(build_client_answer_file_path(file, client_name),

--- a/lib/engines/hcktest/platforms/Win10_2004x86_bios.json
+++ b/lib/engines/hcktest/platforms/Win10_2004x86_bios.json
@@ -1,9 +1,11 @@
 {
-  "name": "Win10_2004x86",
+  "name": "Win10_2004x86_bios",
   "client_iso": "Win10_2004x86",
   "kit": "HLK2004",
   "setupmanager": "qemuhck",
   "st_image": "HLK2004.qcow2",
+  "fw_type": "bios",
+  "client_arch": "x86",
   "clients": {
     "c1": {
       "name": "CL1",

--- a/lib/engines/hcktest/platforms/Win10_22H2x86_bios.json
+++ b/lib/engines/hcktest/platforms/Win10_22H2x86_bios.json
@@ -1,0 +1,25 @@
+{
+  "name": "Win10_22H2x86_bios",
+  "client_iso": "Win10_22H2x86",
+  "kit": "HLK2004",
+  "setupmanager": "qemuhck",
+  "st_image": "HLK2004.qcow2",
+  "fw_type": "bios",
+  "client_arch": "x86",
+  "clients": {
+    "c1": {
+      "name": "CL1",
+      "cpus": 4,
+      "memory_gb": 4,
+      "winrm_addr": "192.168.100.2",
+      "image": "HLK2004-C1-Win10_22H2x86.qcow2"
+    },
+    "c2": {
+      "name": "CL2",
+      "cpus": 4,
+      "memory_gb": 4,
+      "winrm_addr": "192.168.100.3",
+      "image": "HLK2004-C2-Win10_22H2x86.qcow2"
+    }
+  }
+}

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -9,6 +9,7 @@ module AutoHCK
     JUNIT_RESULT = 'junit.xml'
     RESULT_REPORT_HTML = 'results.html'
     RESULT_REPORT_YAML = 'results.yaml'
+    DEFAULT_ARCH = 'amd64'
 
     attr_reader :config, :logger, :timestamp, :setup_manager, :engine, :id,
                 :workspace_path, :result_uploader, :engine_tag,

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -149,7 +149,7 @@ module AutoHCK
 
     def machine_info
       @studio.list_pools.flat_map { |pool| pool['machines'] }
-             .detect { |machine| machine['name'].eql?(@name) }
+                        .detect { |machine| machine['name'].eql?(@name) }
     end
 
     def recognize_client_wait

--- a/lib/setupmanagers/qemuhck/qemu_machine.json
+++ b/lib/setupmanagers/qemuhck/qemu_machine.json
@@ -13,7 +13,10 @@
   "share_on_host_net": "192.168.101",
   "platforms_defaults": {
     "cpu": "host",
-    "cpu_options": "",
+    "cpu_options": {
+      "default": "",
+      "x86": "lm=off,pae=on"
+    },
     "cpu_count": 2,
     "memory_gb": 4,
     "world_net_device": "e1000e",

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -303,6 +303,15 @@ module AutoHCK
 
       states_config = Json.read_json(STATES_JSON, @logger)
       states_config.each { |name, state| apply_state name, state }
+
+      apply_cpu_options_config
+    end
+
+    def apply_cpu_options_config
+      extra = option_config('cpu_options')
+      return if extra.nil? || extra.empty?
+
+      extra.split(',').each { |opt| @cpu_options << opt unless opt.empty? }
     end
 
     def config_replacement_map

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -311,6 +311,14 @@ module AutoHCK
       extra = option_config('cpu_options')
       return if extra.nil? || extra.empty?
 
+      if extra.is_a?(Hash)
+        raise(
+          QemuHCKError,
+          'cpu_options must resolve to a comma-separated String; ' \
+          "hash configuration requires a matching arch key (#{@options['arch']}) or 'default'"
+        )
+      end
+
       extra.split(',').each { |opt| @cpu_options << opt unless opt.empty? }
     end
 

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -254,9 +254,21 @@ module AutoHCK
     end
 
     def option_config(option)
-      return @options[option] if @options.keys.include? option
+      config_data = if @options.keys.include? option
+                      @options[option]
+                    else
+                      @config['platforms_defaults'][option]
+                    end
 
-      @config['platforms_defaults'][option]
+      # If config_data is not a hash, return it as is.
+      # Otherwise, try to return the value for the architecture or the default one or the hash itself.
+      # This allows using the hash itself as a default value or overriding the value for a specific architecture.
+      return config_data unless config_data.is_a?(Hash)
+
+      return config_data[@options['arch']] if config_data.key?(@options['arch'])
+      return config_data['default'] if config_data.key?('default')
+
+      config_data
     end
 
     def apply_state(name, state)

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -105,15 +105,21 @@ module AutoHCK
       }.compact
     end
 
-    def initialize_clients_vm
+    def client_vm_options(client_info, index)
       options = drivers_options.merge(platform_client_options)
+      options.merge({
+        'client_id' => index + 1,
+        'image_name' => client_info['image'],
+        'cpu_count' => client_info['cpus'],
+        'memory_gb' => client_info['memory_gb'],
+        'arch' => client_info['arch'] || @platform['client_arch'] || Project::DEFAULT_ARCH
+      }.merge(client_vm_common_options))
+    end
+
+    def initialize_clients_vm
       @platform['clients'].each_with_index do |(_k, v), i|
-        vm_options = options.merge({
-          'client_id' => i + 1,
-          'image_name' => v['image'],
-          'cpu_count' => v['cpus'],
-          'memory_gb' => v['memory_gb']
-        }.merge(client_vm_common_options))
+        vm_options = client_vm_options(v, i)
+        @logger.debug("Creating client VM #{v['name']} with options: #{vm_options}")
         @clients_vm[v['name']] = QemuMachine.new(vm_options)
       end
     end


### PR DESCRIPTION
lib/engines/hckinstall/answer-files/ has only one small change `processorArchitecture="amd64"` -> `processorArchitecture="@PROCESSOR_ARCHITECTURE@"`, so GitHub shows it wrongly. 

Define Win10_22H2x86_bios platform because for 32-bit, we need another OVMF. Currently, RHEL does not have OVMF x86, so we have no reason to define a UEFI platform for now.

Generate setup iso for each client. This will be used to support different configurations/architectures for different clients on one platform. For example, for mixed testing (not implemented yet)