### PR TITLE
RHELMISC-4745: Add ability to bring up previous session

### DIFF
--- a/bin/auto_hck
+++ b/bin/auto_hck
@@ -6,9 +6,16 @@ Dir.chdir(File.dirname(__dir__))
 require_relative '../lib/auto_hck'
 
 module AutoHCK
+  def self.build_session(cli)
+    session_path = cli.test.latest_session ? "#{Config.read['workspace_path']}/latest" : cli.test.session
+    session_path ? Session.load(session_path, cli.common.workspace_path) : Session.new(cli:)
+  end
+
   run do
     cli = CLI.new
     cli.parse(ARGV)
+
+    session = build_session(cli)
 
     ENV.store 'LC_ALL', 'en_US.UTF-8'
 
@@ -18,7 +25,7 @@ module AutoHCK
     Thread.report_on_exception = false
 
     ResourceScope.open do |scope|
-      @project = Project.new(scope, cli)
+      @project = Project.new(scope, session)
       Trap.project = @project
       @project.run if @project.prepare
     rescue StandardError => e

--- a/lib/all.rb
+++ b/lib/all.rb
@@ -72,6 +72,7 @@ module AutoHCK
   autoload_relative :ReplacementMap, 'auxiliary/replacement_map'
   autoload_relative :ResourceScope, 'auxiliary/resource_scope'
   autoload_relative :ResultUploader, 'resultuploaders/result_uploader'
+  autoload_relative :Session, 'session'
   autoload_relative :SetupManager, 'setupmanagers/setupmanager'
   autoload_relative :SetupManagerError, 'setupmanagers/exceptions'
   autoload_relative :StudioConnectError, 'setupmanagers/exceptions'

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -107,6 +107,8 @@ module AutoHCK
     prop :auto_retry_failed_tests, Integer, default: 0
     prop :query, T.nilable(String)
     prop :query_output_file, T.nilable(String)
+    prop :session, T.nilable(String)
+    prop :latest_session, T::Boolean, default: false
 
     def create_parser
       OptionParser.new do |parser|
@@ -257,6 +259,14 @@ module AutoHCK
       parser.on('--query-output-file <path>', String,
                 'Write query output to the specified file in addition to the log',
                 &method(:query_output_file=))
+
+      parser.on('--session <path>', String,
+                'Bring up a previous test session from its workspace path',
+                &method(:session=))
+
+      parser.on('--latest-session', TrueClass,
+                'Bring up the most recent test session',
+                &method(:latest_session=))
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -209,6 +209,7 @@ module AutoHCK
       configure_and_synchronize_clients
       @studio.keep_snapshot
       @clients.each_value(&:keep_snapshot)
+      @project.save_session unless @project.restored?
     end
 
     def run_clients_and_configure_setup(scope, **opts)
@@ -314,32 +315,50 @@ module AutoHCK
       e
     end
 
+    def init_vm_options
+      return {} unless @project.restored?
+
+      { boot_from_snapshot: true, create_snapshot: false }
+    end
+
+    def run_restored_session
+      ResourceScope.open do |scope|
+        run_clients_and_configure_setup(scope, **init_vm_options)
+        prepare_tests
+        pause_run
+      end
+    end
+
+    def run_fresh_session
+      # Try to export the project package even if some of the steps fail, it can be
+      # used to simplify the HLK process by reusing the created package and just fixing
+      # the root cause of the failure without the need to run all other tests
+      ex1 = rescue2return { run_tests_without_config }
+      ex2 = rescue2return { run_tests_with_config }
+      ex3 = rescue2return { @tests.create_project_package }
+
+      # Sometimes results file missing filters for last test
+      # After creating project package, all filters should be applied
+      # Reload tests and update results to make sure the final report is correct
+      ex4 = rescue2return { @tests.update_tests_and_results }
+
+      # Propagate the first exception if any occurred; the most likely other exceptions are just
+      # consequences of the first one and will be resolved after fixing the first root cause
+      [ex1, ex2, ex3, ex4].each { |e| raise e if e }
+    end
+
     def auto_run
       ResourceScope.open do |scope|
-        run_studio scope
+        run_studio(scope, **init_vm_options)
         sleep 5 until @studio.up?
-        # Try to export the project package even if some of the steps fail, it can be
-        # used to simplify the HLK process by reusing the created package and just fixing
-        # the root cause of the failure without the need to run all other tests
-        ex1 = rescue2return { run_tests_without_config }
-        ex2 = rescue2return { run_tests_with_config }
 
-        ex3 = rescue2return { @tests.create_project_package }
-
-        # Sometimes results file missing filters for last test
-        # After creating project package, all filters should be applied
-        # Reload tests and update results to make sure the final report is correct
-        ex4 = rescue2return { @tests.update_tests_and_results }
-
-        # Propagate the first exception if any occurred; the most likely other exceptions are just
-        # consequences of the first one and will be resolved after fixing the first root cause
-        [ex1, ex2, ex3, ex4].each { |e| raise e if e }
+        @project.restored? ? run_restored_session : run_fresh_session
       end
     end
 
     def run_tests_without_config
       ResourceScope.open do |scope|
-        run_clients_and_configure_setup scope
+        run_clients_and_configure_setup(scope, **init_vm_options)
         prepare_tests
 
         @logger.info('Client ready, running basic tests')
@@ -388,8 +407,14 @@ module AutoHCK
       grouped_tests
     end
 
+    def upload_driver_package_if_needed
+      return if @driver_path.nil? || @project.restored?
+
+      upload_driver_package
+    end
+
     def run
-      upload_driver_package unless @driver_path.nil?
+      upload_driver_package_if_needed
 
       if @project.options.test.dump
         @project.logger.info('AutoHCK started in dump only mode')

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -16,16 +16,20 @@ module AutoHCK
                 :engine_platform, :engine_type, :options, :extra_sw_manager,
                 :run_terminated, :engine_name, :string_log, :status, :whiteboard
 
-    def initialize(scope, options)
+    def apply_json_override
+      Json.update_json_override(@options.common.config) unless @options.common.config.nil?
+    end
+
+    def initialize(scope, session)
       @scope = scope
-      @options = options
-      common = options.common
+      @options = session.cli
+      @session = session
       init_timestamp
-      Json.update_json_override(common.config) unless common.config.nil?
-      init_multilog(common.verbose)
+      apply_json_override
+      init_multilog(@options.common.verbose)
       init_class_variables
       init_workspace
-      @id = common.id
+      @id = @options.common.id
       print_whiteboard
       # ResultUploader must be initialized before adding project to scope
       # Project uses ResultUploader on close, so ResultUploader must exist
@@ -220,14 +224,15 @@ module AutoHCK
       @options.mode == 'test' && !@options.test.query.nil?
     end
 
-    def init_workspace
-      return if query_mode?
+    def restored?
+      !@options.test.session.nil?
+    end
 
-      unless @options.common.workspace_path.nil?
-        @workspace_path = @options.common.workspace_path
-        return
-      end
+    def save_session
+      @session.save(@workspace_path, @logger)
+    end
 
+    def create_workspace
       @workspace_path = File.join(@config['workspace_path'], @engine_name,
                                   @engine_tag, @timestamp)
       begin
@@ -244,6 +249,22 @@ module AutoHCK
       end
 
       File.symlink(@workspace_path, "#{@config['workspace_path']}/latest")
+    end
+
+    def restore_workspace
+      @workspace_path = @options.test.session
+      @logger.info("Restoring workspace from #{@workspace_path}")
+    end
+
+    def init_workspace
+      return if query_mode?
+
+      unless @options.common.workspace_path.nil?
+        @workspace_path = @options.common.workspace_path
+        return
+      end
+
+      restored? ? restore_workspace : create_workspace
       @setup_manager_type&.enter @workspace_path
     end
 
@@ -262,6 +283,8 @@ module AutoHCK
     end
 
     def generate_junit
+      return if restored?
+
       results_file = "#{@workspace_path}/#{JUNIT_RESULT}"
 
       @junit.generate(results_file)

--- a/lib/session.rb
+++ b/lib/session.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+
+module AutoHCK
+  class Session < T::Struct
+    extend T::Sig
+    extend Models::JsonHelper
+
+    prop :cli, CLI
+
+    sig { params(workspace_path: String, logger: AutoHCK::MultiLogger).void }
+    def save(workspace_path, logger)
+      data = cli.serialize
+      File.write("#{workspace_path}/session.json", data.to_json)
+      logger.info("Session saved to #{workspace_path}/session.json")
+    end
+
+    sig { params(session_path: String, workspace_path: T.nilable(String)).returns(Session) }
+    def self.load(session_path, workspace_path)
+      resolved_path = File.realpath(session_path)
+      cli = CLI.from_hash(read_session_data(resolved_path))
+      cli.common.workspace_path = workspace_path
+      cli.test.session = resolved_path
+      cli.test.manual = true
+      new(cli:)
+    rescue SystemCallError, JSON::ParserError => e
+      raise AutoHCKError, "Failed to load session from #{session_path}: #{e.message}"
+    end
+
+    def self.read_session_data(resolved_path)
+      data = JSON.parse(File.read("#{resolved_path}/session.json"))
+      data['test']['package_with_driver'] = data['test']['package_with_driver']&.to_sym
+      data
+    end
+
+    private_class_method :read_session_data
+  end
+end

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -35,6 +35,10 @@ module AutoHCK
       @runner.keep_snapshot
     end
 
+    def search_target
+      @target = Targets.new(self, @project, @tools, pool).search_target
+    end
+
     def add_target_to_project
       @target = Targets.new(self, @project, @tools, pool).add_target_to_project
     end
@@ -169,6 +173,12 @@ module AutoHCK
       initialize_client_wait
     end
 
+    def return_when_client_restored
+      @logger.info("Waiting for client #{@name} to rejoin pool #{@project.engine_tag}")
+      sleep 5 until pool == @project.engine_tag
+      @logger.info("Client #{@name} rejoined pool #{@project.engine_tag}")
+    end
+
     def prepare_machine
       @logger.info("Preparing client #{@name}...")
       @project.extra_sw_manager.install_software_before_driver(@tools, @name)
@@ -177,23 +187,34 @@ module AutoHCK
       @project.extra_sw_manager.install_software_after_driver(@tools, @name)
     end
 
+    def configure_restored
+      return_when_client_restored
+      initialize_client_wait
+      configure_machine
+      search_target
+    end
+
+    def configure_fresh(run_only:)
+      unless pool == @project.engine_tag
+        return_when_client_up
+        if run_only
+          @logger.info("Preparing client skipped #{@name}...")
+
+          Thread.exit
+        end
+        prepare_machine
+        move_machine_to_pool
+      end
+
+      configure_machine
+      run_post_start_commands
+      add_target_to_project
+    end
+
     def configure(run_only: false)
       @tools = @studio.tools
       @cooldown_thread = Thread.new do
-        unless pool == @project.engine_tag
-          return_when_client_up
-          if run_only
-            @logger.info("Preparing client skipped #{@name}...")
-
-            Thread.exit
-          end
-          prepare_machine
-          move_machine_to_pool
-        end
-
-        configure_machine
-        run_post_start_commands
-        add_target_to_project
+        @project.restored? ? configure_restored : configure_fresh(run_only:)
       end
     end
 

--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -80,6 +80,8 @@ module AutoHCK
       connect
       verify_tools
       update_filters
+      return if @project.restored?
+
       create_pool
       create_project
     end

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -759,7 +759,7 @@ module AutoHCK
 
     def run(scope, run_opts = nil)
       @run_opts = validate_run_opts(run_opts.to_h)
-      @keep_alive = run_opts[:keep_alive]
+      @keep_alive = @run_opts[:keep_alive]
 
       process_device_commands
       normalize_lists
@@ -767,7 +767,7 @@ module AutoHCK
       if @run_opts[:dump_only]
         dump_commands
       else
-        unless @configured
+        unless @configured || @run_opts[:boot_from_snapshot]
           run_config_commands
           @configured = true
         end

--- a/spec/integration/cli_query_images_names_spec.rb
+++ b/spec/integration/cli_query_images_names_spec.rb
@@ -39,7 +39,7 @@ describe 'CLI and Project#prepare query mode (images-names)', :integration do
       expect(cli.test.platform).to eq('Win10_2004x64')
 
       AutoHCK::ResourceScope.open do |scope|
-        project = AutoHCK::Project.new(scope, cli)
+        project = AutoHCK::Project.new(scope, AutoHCK::Session.new(cli:))
         expect(project.prepare).to be(false)
         expect(project.engine).to be_nil
       end
@@ -58,7 +58,7 @@ describe 'CLI and Project#prepare query mode (images-names)', :integration do
     cli.parse(['test', '-p', 'Win10_2004x64', '--query', 'images-names'])
 
     AutoHCK::ResourceScope.open do |scope|
-      project = AutoHCK::Project.new(scope, cli)
+      project = AutoHCK::Project.new(scope, AutoHCK::Session.new(cli:))
       expect(project.prepare).to be(false)
       log = project.string_log.string
       expect(log).to include('Studio image: HLK2004.qcow2')
@@ -73,7 +73,7 @@ describe 'CLI and Project#prepare query mode (images-names)', :integration do
 
     expect do
       AutoHCK::ResourceScope.open do |scope|
-        AutoHCK::Project.new(scope, cli).prepare
+        AutoHCK::Project.new(scope, AutoHCK::Session.new(cli:)).prepare
       end
     end.to raise_error(AutoHCK::AutoHCKError, /Unknown query: unknown-query/)
   end


### PR DESCRIPTION
Save CLI options to session.json after VMs are configured and snapshots are kept. Use --session <path> or --latest-session to boot VMs from snapshots, reconnect to the existing HLK project and enter manual mode.