### PR TITLE
Update storage drivers config

### DIFF
--- a/lib/engines/hcktest/drivers/vioscsi.json
+++ b/lib/engines/hcktest/drivers/vioscsi.json
@@ -20,8 +20,9 @@
       "tests": [
         "Flush Test"
       ],
-      "kits": ["HLK2022"],
-      "errata": "Flush Test - known HLK failure on Win2022"
+      "kits": ["HLK2004", "HLK2022"],
+      "skip_retry": true,
+      "errata": "Flush Test - known HLK failure on Windows Server 2022 and Windows 10 22H2"
     },
     {
       "tests": [

--- a/lib/engines/hcktest/drivers/viostor.json
+++ b/lib/engines/hcktest/drivers/viostor.json
@@ -20,8 +20,9 @@
       "tests": [
         "Flush Test"
       ],
-      "kits": ["HLK2022"],
-      "errata": "Flush Test - known HLK failure on Win2022"
+      "kits": ["HLK2004", "HLK2022"],
+      "skip_retry": true,
+      "errata": "Flush Test - known HLK failure on Windows Server 2022 and Windows 10 22H2"
     },
     {
       "tests": [


### PR DESCRIPTION
Flush Test fails on Windows 10 22H2 (HLK 2004).
Skip retry because we have a manual errata for it.