### PR TITLE
RHELMISC-2846: [SVVP] add sequence_test_names to enforce test execution order

### DIFF
--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -131,6 +131,7 @@ module AutoHCK
           'name' => @clients.values[0].name,
           'type' => @svvp_info.type,
           'select_test_names' => @svvp_info.select_test_names,
+          'sequence_test_names' => @svvp_info.sequence_test_names,
           'reject_test_names' => @svvp_info.reject_test_names
         }
       else
@@ -139,6 +140,7 @@ module AutoHCK
           'name' => driver.name,
           'type' => driver.type,
           'select_test_names' => driver.select_test_names,
+          'sequence_test_names' => [],
           'reject_test_names' => driver.reject_test_names
         }
       end

--- a/lib/engines/hcktest/playlist.rb
+++ b/lib/engines/hcktest/playlist.rb
@@ -51,6 +51,7 @@ module AutoHCK
       custom_select_test_names(log)
       custom_reject_test_names(log)
       sort_by_duration
+      reorder_sequence_tests
     end
 
     def update_target(target)
@@ -96,6 +97,17 @@ module AutoHCK
     sig { returns(T::Array[Models::HLK::Test]) }
     def sort_by_duration
       @tests.sort_by!(&:duration)
+    end
+
+    # Move tests listed in sequence_test_names to the end in the specified order.
+    def reorder_sequence_tests
+      sequence_names = @project.engine.target['sequence_test_names']
+
+      matched, remaining = @tests.partition { |t| sequence_names.include?(t.name) }
+      return @tests if matched.empty?
+
+      matched.sort_by! { |t| sequence_names.index(t.name) }
+      @tests = remaining + matched
     end
 
     def intersect_select_tests(select_test_names)

--- a/lib/models/svvp_config.rb
+++ b/lib/models/svvp_config.rb
@@ -17,6 +17,7 @@ module AutoHCK
 
       const :select_test_names, T.nilable(T::Array[String])
       const :reject_test_names, T.nilable(T::Array[String])
+      const :sequence_test_names, T::Array[String], default: []
     end
   end
 end


### PR DESCRIPTION
Some tests require a strict execution order. Add sequence_test_names to svvp_config to move matching tests to the end of the list in the declared order, applied after all other filtering.