### PR TITLE
RHELMISC 34338: Add client role support (DUT/SUT/Support/Master/Stress)

### DIFF
--- a/lib/all.rb
+++ b/lib/all.rb
@@ -47,6 +47,7 @@ module AutoHCK
   autoload_relative :HCKInstall, 'engines/hckinstall/hckinstall'
   autoload_relative :HCKStudio, 'setupmanagers/hckstudio'
   autoload_relative :HCKTest, 'engines/hcktest/hcktest'
+  autoload_relative :PlatformClients, 'engines/hcktest/platform_clients'
   autoload_relative :Helper, 'helper'
   autoload_relative :InvalidConfigFile, 'exceptions'
   autoload_relative :InvalidEngineTypeError, 'engines/exceptions'

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -8,7 +8,7 @@ module AutoHCK
     extend T::Sig
     include Helper
 
-    attr_reader :config, :drivers, :platform, :extensions
+    attr_reader :config, :drivers, :platform, :extensions, :platform_clients
 
     PLATFORMS_JSON_DIR = 'lib/engines/hcktest/platforms'
     CONFIG_JSON = 'lib/engines/hcktest/hcktest.json'
@@ -17,6 +17,16 @@ module AutoHCK
     SVVP_JSON = 'svvp.json'
     ENGINE_MODE = 'test'
     AUTOHCK_RETRIES = 5
+
+    # Maps platform roles to the HLK machine-set role names used in QueueTest.
+    HLK_ROLE_MAP = {
+      Models::ClientRole::Support => 'Support',
+      Models::ClientRole::Master => 'MC',
+      Models::ClientRole::Stress => 'SC'
+    }.freeze
+
+    # Roles that are the primary test target
+    PRIMARY_ROLES = [Models::ClientRole::Dut, Models::ClientRole::Sut].freeze
 
     def initialize(project)
       @project = project
@@ -28,6 +38,12 @@ module AutoHCK
       @extensions = find_extensions
       prepare_extra_sw
       validate_paths unless @driver_path.nil?
+      @platform_clients = build_platform_clients
+    end
+
+    sig { returns(PlatformClients) }
+    def build_platform_clients
+      PlatformClients.new(@project.engine_platform, logger: @logger)
     end
 
     def test_steps
@@ -126,24 +142,31 @@ module AutoHCK
     end
 
     def target
-      if @project.options.test.svvp
-        {
-          'name' => @clients.values[0].name,
-          'type' => @svvp_info.type,
-          'select_test_names' => @svvp_info.select_test_names,
-          'sequence_test_names' => @svvp_info.sequence_test_names,
-          'reject_test_names' => @svvp_info.reject_test_names
-        }
-      else
-        driver = drivers.first
-        {
-          'name' => driver.name,
-          'type' => driver.type,
-          'select_test_names' => driver.select_test_names,
-          'sequence_test_names' => [],
-          'reject_test_names' => driver.reject_test_names
-        }
-      end
+      @project.options.test.svvp ? svvp_target : whql_target
+    end
+
+    def svvp_target
+      primary_entry = @platform_clients.primary_entry
+      raise InvalidConfigFile, 'SVVP platform is missing a sut client' if primary_entry.nil?
+
+      {
+        'name' => primary_entry['name'],
+        'type' => @svvp_info.type,
+        'select_test_names' => @svvp_info.select_test_names,
+        'sequence_test_names' => @svvp_info.sequence_test_names,
+        'reject_test_names' => @svvp_info.reject_test_names
+      }
+    end
+
+    def whql_target
+      driver = drivers.first
+      {
+        'name' => driver.name,
+        'type' => driver.type,
+        'select_test_names' => driver.select_test_names,
+        'sequence_test_names' => [],
+        'reject_test_names' => driver.reject_test_names
+      }
     end
 
     sig { params(logger: MultiLogger, options: CLI).returns(Models::HLKPlatform) }
@@ -168,16 +191,17 @@ module AutoHCK
 
     def run_clients(scope, run_opts = {})
       @clients = {}
-      @project.engine_platform.clients.each_value do |client|
-        @clients[client.name] = @project.setup_manager.run_hck_client(scope, @studio, client.name, run_opts)
+      @platform_clients.entries.each { |client| start_client(scope, client, run_opts) }
+      raise InvalidConfigFile, 'Clients configuration for this platform is incorrect' if @clients.empty?
+    end
 
-        break if @project.options.test.svvp
-        break unless @drivers.any?(&:support)
-      end
-      return unless @clients.empty?
+    def start_client(scope, client, run_opts)
+      name = client['name']
+      role = client['role']
+      return if !PRIMARY_ROLES.include?(role) && !@project.options.test.svvp && @drivers.none?(&:support)
 
-      raise InvalidConfigFile, 'Clients configuration for \
-                                this platform is incorrect'
+      @logger.info("Starting client #{name} (role: #{role})")
+      @clients[name] = @project.setup_manager.run_hck_client(scope, @studio, name, run_opts)
     end
 
     def post_start_commands
@@ -296,14 +320,16 @@ module AutoHCK
     end
 
     def prepare_tests
-      client, support = @clients.values
+      client = primary_client
+      aux_clients = aux_clients_by_hlk_role
 
-      @tests = Tests.new(client, support, @project, client.target, @studio.tools)
+      @tests = Tests.new(client, @project, client.target, @studio.tools, aux_clients: aux_clients)
 
       if client.target.nil?
         raise EngineError, 'HLK test target is not defined' unless @project.options.test.manual
 
         @project.logger.info('HLK test target is not defined, allow in manual mode')
+        return
       end
 
       @test_list = @tests.update_tests(log: true)
@@ -433,6 +459,30 @@ module AutoHCK
 
     def result_uploader_needed?
       true
+    end
+
+    private
+
+    sig { returns(T::Hash[String, T::Array[HCKClient]]) }
+    def aux_clients_by_hlk_role
+      @platform_clients.entries
+                       .reject { |e| PRIMARY_ROLES.include?(e['role']) }
+                       .each_with_object({}) do |e, result|
+                         hlk_role = HLK_ROLE_MAP[e['role']]
+                         client = @clients[e['name']]
+                         (result[hlk_role] ||= []) << client if hlk_role && client
+                       end
+    end
+
+    sig { returns(HCKClient) }
+    def primary_client
+      entry = @platform_clients.primary_entry
+      raise InvalidConfigFile, 'Platform is missing a primary client (sut or dut)' if entry.nil?
+
+      client = @clients[entry['name']]
+      raise InvalidConfigFile, "Client #{entry['name']} was not started" if client.nil?
+
+      client
     end
   end
 end

--- a/lib/engines/hcktest/platform_clients.rb
+++ b/lib/engines/hcktest/platform_clients.rb
@@ -1,0 +1,117 @@
+# typed: true
+# frozen_string_literal: true
+
+# AutoHCK module
+module AutoHCK
+  # Reads client roles from a platform JSON and exposes helpers used by the engine.
+  class PlatformClients
+    extend T::Sig
+
+    ClientEntry = T.type_alias { T::Hash[String, T.untyped] }
+
+    # Allowed role sets for WHQL platforms.
+    WHQL_CONFIGURATIONS = [
+      [Models::ClientRole::Dut],
+      [Models::ClientRole::Dut, Models::ClientRole::Support]
+    ].freeze
+
+    # Minimum roles required for SVVP. Extra stress clients are fine.
+    SVVP_REQUIRED_ROLES = [Models::ClientRole::Sut, Models::ClientRole::Master].freeze
+
+    # MC and SC join the pool but skip driver install and HLK target registration.
+    POOL_ONLY_ROLES = [Models::ClientRole::Master, Models::ClientRole::Stress].freeze
+
+    sig do
+      params(
+        platform: Models::HLKPlatform,
+        logger: T.any(MultiLogger, ::Logger)
+      ).void
+    end
+    def initialize(platform, logger:)
+      @logger = logger
+      @entries = build_entries(platform.clients)
+      validate!
+    end
+
+    # All clients in platform order.
+    attr_reader :entries
+
+    # Role for a given machine name.
+    sig { params(name: String).returns(Models::ClientRole) }
+    def role_for(name)
+      entry = @entries.find { |e| e['name'] == name }
+      raise InvalidConfigFile, "Unknown client #{name} in platform configuration" if entry.nil?
+
+      entry.fetch('role')
+    end
+
+    # First entry whose role matches (nil if not found).
+    sig { params(role: Models::ClientRole).returns(T.nilable(ClientEntry)) }
+    def entry_for_role(role)
+      @entries.find { |e| e['role'] == role }
+    end
+
+    # The primary client entry — SUT for SVVP, DUT for WHQL.
+    sig { returns(T.nilable(ClientEntry)) }
+    def primary_entry
+      entry_for_role(Models::ClientRole::Sut) || entry_for_role(Models::ClientRole::Dut)
+    end
+
+    sig { params(name: String).returns(T::Boolean) }
+    def pool_only?(name)
+      POOL_ONLY_ROLES.include?(role_for(name))
+    end
+
+    private
+
+    sig { params(clients: T::Hash[String, Models::HLKClient]).returns(T::Array[ClientEntry]) }
+    def build_entries(clients)
+      clients.map do |key, client|
+        client_hash = client.serialize
+        role = resolve_role(client_hash)
+        client_hash.merge('role' => role, '_key' => key)
+      end
+    end
+
+    sig { params(client: T::Hash[String, T.untyped]).returns(Models::ClientRole) }
+    def resolve_role(client)
+      raw_role = client['role']
+
+      if raw_role.nil? || raw_role.to_s.strip.empty?
+        raise InvalidConfigFile,
+              "Client '#{client['name']}' is missing a 'role' field in the platform JSON."
+      end
+
+      Models::ClientRole.deserialize(raw_role.strip.downcase)
+    rescue KeyError
+      raise InvalidConfigFile, "Client '#{client['name']}' has unknown role #{raw_role.inspect}. " \
+                               "Expected one of: #{Models::ClientRole.values.join(', ')}"
+    end
+
+    sig { void }
+    def validate!
+      roles = @entries.map { |e| e.fetch('role') }
+      return if valid_whql_configuration?(roles) || valid_svvp_configuration?(roles)
+
+      raise InvalidConfigFile, invalid_roles_message(roles)
+    end
+
+    sig { params(roles: T::Array[Models::ClientRole]).returns(T::Boolean) }
+    def valid_whql_configuration?(roles)
+      WHQL_CONFIGURATIONS.any? { |config| roles.sort_by(&:to_s) == config.sort_by(&:to_s) }
+    end
+
+    sig { params(roles: T::Array[Models::ClientRole]).returns(T::Boolean) }
+    def valid_svvp_configuration?(roles)
+      SVVP_REQUIRED_ROLES.all? { |role| roles.include?(role) }
+    end
+
+    sig { params(roles: T::Array[Models::ClientRole]).returns(String) }
+    def invalid_roles_message(roles)
+      role_list = roles.join(', ')
+      whql_list = WHQL_CONFIGURATIONS.map { |c| c.join(', ') }.join(' | ')
+      "Invalid platform client roles [#{role_list}]. " \
+        "Expected WHQL (#{whql_list}) or SVVP (must include: #{SVVP_REQUIRED_ROLES.join(', ')})."
+    end
+  end
+end

--- a/lib/engines/hcktest/platforms/PhyWin2016.json
+++ b/lib/engines/hcktest/platforms/PhyWin2016.json
@@ -5,6 +5,7 @@
   "clients": {
     "c1": {
       "name": "C1",
+      "role": "dut",
       "winrm_port": 4002
     }
   }

--- a/lib/engines/hcktest/platforms/PhyWin2019.json
+++ b/lib/engines/hcktest/platforms/PhyWin2019.json
@@ -5,6 +5,7 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "winrm_port": 4002
     }
   }

--- a/lib/engines/hcktest/platforms/Win10_2004x64.json
+++ b/lib/engines/hcktest/platforms/Win10_2004x64.json
@@ -7,16 +7,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 4,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2004-C1-Win10_2004x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 4,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2004-C2-Win10_2004x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win10_2004x86_bios.json
+++ b/lib/engines/hcktest/platforms/Win10_2004x86_bios.json
@@ -11,6 +11,7 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 4,
       "winrm_addr": "192.168.100.2",
@@ -18,6 +19,7 @@
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 4,
       "winrm_addr": "192.168.100.3",

--- a/lib/engines/hcktest/platforms/Win10_22H2x64.json
+++ b/lib/engines/hcktest/platforms/Win10_22H2x64.json
@@ -7,6 +7,7 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
       "winrm_addr": "192.168.100.2",
@@ -14,6 +15,7 @@
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
       "winrm_addr": "192.168.100.3",

--- a/lib/engines/hcktest/platforms/Win10_22H2x86_bios.json
+++ b/lib/engines/hcktest/platforms/Win10_22H2x86_bios.json
@@ -11,6 +11,7 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 4,
       "winrm_addr": "192.168.100.2",
@@ -18,6 +19,7 @@
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 4,
       "winrm_addr": "192.168.100.3",

--- a/lib/engines/hcktest/platforms/Win11_22H2x64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_22H2x64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_22H2-C1-Win11_22H2x64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_22H2-C2-Win11_22H2x64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win11_23H2x64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_23H2x64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_23H2-C1-Win11_23H2x64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_23H2-C2-Win11_23H2x64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win11_24H2x64.json
+++ b/lib/engines/hcktest/platforms/Win11_24H2x64.json
@@ -9,16 +9,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_24H2-C1-Win11_24H2x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_24H2-C2-Win11_24H2x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win11_24H2x64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_24H2x64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_24H2-C1-Win11_24H2x64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_24H2-C2-Win11_24H2x64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win11_25H2x64.json
+++ b/lib/engines/hcktest/platforms/Win11_25H2x64.json
@@ -9,16 +9,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_25H2-C1-Win11_25H2x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_25H2-C2-Win11_25H2x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win11_25H2x64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11_25H2x64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_25H2-C1-Win11_25H2x64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_25H2-C2-Win11_25H2x64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win11nextx64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win11nextx64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK11_next-C1-Win11nextx64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK11_next-C2-Win11nextx64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2016x64.json
+++ b/lib/engines/hcktest/platforms/Win2016x64.json
@@ -7,16 +7,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 2,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK1607-C1-Win2016x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 2,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK1607-C2-Win2016x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2016x64_bios.json
+++ b/lib/engines/hcktest/platforms/Win2016x64_bios.json
@@ -8,16 +8,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 2,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK1607-C1-Win2016x64-bios.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 2,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK1607-C2-Win2016x64-bios.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2016x64_gui.json
+++ b/lib/engines/hcktest/platforms/Win2016x64_gui.json
@@ -7,6 +7,7 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
       "winrm_addr": "192.168.100.2",
@@ -14,6 +15,7 @@
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
       "winrm_addr": "192.168.100.3",

--- a/lib/engines/hcktest/platforms/Win2019x64.json
+++ b/lib/engines/hcktest/platforms/Win2019x64.json
@@ -7,16 +7,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK1809-C1-Win2019x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK1809-C2-Win2019x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2019x64_bios.json
+++ b/lib/engines/hcktest/platforms/Win2019x64_bios.json
@@ -8,16 +8,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK1809-C1-Win2019x64-bios.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK1809-C2-Win2019x64-bios.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2019x64_gui.json
+++ b/lib/engines/hcktest/platforms/Win2019x64_gui.json
@@ -7,16 +7,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK1809-C1-Win2019x64-gui.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK1809-C2-Win2019x64-gui.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2022x64.json
+++ b/lib/engines/hcktest/platforms/Win2022x64.json
@@ -8,16 +8,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2022-C1-Win2022x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2022-C2-Win2022x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2022x64_bios.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_bios.json
@@ -8,16 +8,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2022-C1-Win2022x64-bios.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2022-C2-Win2022x64-bios.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2022x64_gui.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_gui.json
@@ -8,16 +8,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2022-C1-Win2022x64-gui.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2022-C2-Win2022x64-gui.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2022x64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2022x64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2022-C1-Win2022x64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2022-C2-Win2022x64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2025nextx64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2025nextx64_viommu.json
@@ -12,6 +12,7 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
       "winrm_addr": "192.168.100.2",
@@ -19,6 +20,7 @@
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
       "winrm_addr": "192.168.100.3",

--- a/lib/engines/hcktest/platforms/Win2025x64.json
+++ b/lib/engines/hcktest/platforms/Win2025x64.json
@@ -9,16 +9,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2025-C1-Win2025x64.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2025-C2-Win2025x64.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2025x64_gui.json
+++ b/lib/engines/hcktest/platforms/Win2025x64_gui.json
@@ -9,16 +9,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2025-C1-Win2025x64-gui.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2025-C2-Win2025x64-gui.qcow2"
     }
   }

--- a/lib/engines/hcktest/platforms/Win2025x64_viommu.json
+++ b/lib/engines/hcktest/platforms/Win2025x64_viommu.json
@@ -12,16 +12,18 @@
   "clients": {
     "c1": {
       "name": "CL1",
+      "role": "dut",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.2",
+      "winrm_addr": "192.168.100.2",
       "image": "HLK2025-C1-Win2025x64-viommu.qcow2"
     },
     "c2": {
       "name": "CL2",
+      "role": "support",
       "cpus": 4,
       "memory_gb": 8,
-      "winrm_addr":  "192.168.100.3",
+      "winrm_addr": "192.168.100.3",
       "image": "HLK2025-C2-Win2025x64-viommu.qcow2"
     }
   }

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -23,13 +23,13 @@ module AutoHCK
     DEFAULT_FILE_ACTION_REMOTE_PATH = 'C:\\'
     DEFAULT_FILE_ACTION_LOCAL_PATH = '@workspace@'
 
-    def initialize(client, support, project, target, tools)
+    def initialize(client, project, target, tools, aux_clients: {})
       @client = client
       @project = project
       @tag = project.engine_tag
       @target = target
       @tools = tools
-      @support = support
+      @aux_clients = aux_clients
       @logger = project.logger
       @playlist = Playlist.new(client, project, target, tools, @client.kit)
       @tests = T.let([], T::Array[Models::HLK::Test])
@@ -102,8 +102,15 @@ module AutoHCK
       (test.scheduleoptions & %w[6 RequiresMultipleMachines]) != []
     end
 
+    # The primary auxiliary client (WHQL support machine), nil in SVVP mode.
+    def support_client
+      @aux_clients[HCKTest::HLK_ROLE_MAP[Models::ClientRole::Support]]&.first
+    end
+
     def test_support(test)
-      @support.name if support_needed?(test)
+      return unless support_needed?(test) && @aux_clients.any?
+
+      @aux_clients.transform_values { |clients| clients.map(&:name) }.to_json
     end
 
     sig { params(test: Models::HLK::Test, status: String).void }
@@ -215,9 +222,9 @@ module AutoHCK
       return unless command.guest_run
 
       run_command_on_client(@client, command.guest_run, command.desc, command.guest_reboot, replacement)
-      return if @support.nil?
+      return if support_client.nil?
 
-      run_command_on_client(@support, command.guest_run, command.desc, command.guest_reboot, replacement)
+      run_command_on_client(support_client, command.guest_run, command.desc, command.guest_reboot, replacement)
     end
 
     def run_host_test_command(command)
@@ -293,9 +300,9 @@ module AutoHCK
 
         prepare_file_action_for_client(@client.name, files_action, replacement)
 
-        next if @support.nil?
+        next if support_client.nil?
 
-        prepare_file_action_for_client(@support.name, files_action, replacement)
+        prepare_file_action_for_client(support_client.name, files_action, replacement)
       end
     end
 
@@ -520,13 +527,10 @@ module AutoHCK
     end
 
     def download_memory_dumps(l_tmp_path)
-      downloaded_client = download_memory_dump(@client.name, "#{l_tmp_path}/#{@client.name}_#{current_timestamp}")
-      unless @support.nil?
-        downloaded_support = download_memory_dump(@support.name,
-                                                  "#{l_tmp_path}/#{@support.name}_#{current_timestamp}")
-      end
-
-      downloaded_client || downloaded_support
+      all_clients = [@client] + @aux_clients.values.flatten
+      all_clients.map do |client|
+        download_memory_dump(client.name, "#{l_tmp_path}/#{client.name}_#{current_timestamp}")
+      end.any?
     end
 
     sig { params(test: Models::HLK::Test).void }
@@ -590,7 +594,7 @@ module AutoHCK
 
     def reset_clients_to_ready_state
       @client.reset_to_ready_state
-      @support&.reset_to_ready_state
+      @aux_clients.each_value { |clients| clients.each(&:reset_to_ready_state) }
     end
 
     def apply_filters
@@ -702,9 +706,9 @@ module AutoHCK
       client_sysinfo = parser.parse(@tools.get_machine_system_info(@client.name))
       build_system_info(client_sysinfo)
 
-      return if @support.nil?
+      return if support_client.nil?
 
-      support_sysinfo = parser.parse(@tools.get_machine_system_info(@support.name))
+      support_sysinfo = parser.parse(@tools.get_machine_system_info(support_client.name))
       build_system_info(support_sysinfo)
     end
 

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -15,6 +15,7 @@ module AutoHCK
     autoload_relative :HLKPlatformClientsOptions, 'models/hlk_platform'
     autoload_relative :HLKClient, 'models/hlk_platform'
     autoload_relative :HLKPlatform, 'models/hlk_platform'
+    autoload_relative :ClientRole, 'models/client_role'
     autoload_relative :SVVPConfig, 'models/svvp_config'
     autoload_relative :QemuHCKDevice, 'models/qemuhck_device'
     autoload_relative :HLK, 'models/hlk'

--- a/lib/models/client_role.rb
+++ b/lib/models/client_role.rb
@@ -1,0 +1,26 @@
+# typed: strict
+# frozen_string_literal: true
+
+# AutoHCK module
+module AutoHCK
+  # Models module
+  module Models
+    # Client role in an HLK pool (platform configuration).
+    class ClientRole < T::Enum
+      extend T::Sig
+
+      enums do
+        Dut     = new('dut')     # Device Under Test (WHQL)
+        Sut     = new('sut')     # System Under Test (SVVP)
+        Support = new('support') # Support Client for DUT (WHQL)
+        Master  = new('master')  # Master Client (SVVP)
+        Stress  = new('stress')  # Stress Client (SVVP)
+      end
+
+      sig { returns(String) }
+      def to_s
+        serialize
+      end
+    end
+  end
+end

--- a/lib/models/hlk_platform.rb
+++ b/lib/models/hlk_platform.rb
@@ -31,6 +31,7 @@ module AutoHCK
       extend JsonHelper
 
       const :name, String
+      const :role, T.nilable(String)
       const :cpus, T.nilable(Integer)
       const :memory_gb, T.nilable(Integer)
       const :winrm_addr, T.nilable(String)
@@ -85,6 +86,7 @@ module AutoHCK
 
       sig { params(client: HLKClient).void }
       def validate_qemuhck_client(client)
+        raise(InvalidConfigFile, 'HLKPlatform: client.role is required for qemuhck') if client.role.nil?
         raise(InvalidConfigFile, 'HLKPlatform: client.cpus is required for qemuhck') if client.cpus.nil?
         raise(InvalidConfigFile, 'HLKPlatform: client.memory_gb is required for qemuhck') if client.memory_gb.nil?
         raise(InvalidConfigFile, 'HLKPlatform: client.winrm_addr is required for qemuhck') if client.winrm_addr.nil?

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -78,7 +78,13 @@ module AutoHCK
       raise ClientRunError, "Couldn't set #{@name} state to Ready"
     end
 
+    def pool_only_client?
+      @project.engine.platform_clients.pool_only?(@name)
+    end
+
     def post_start_commands
+      return [] if pool_only_client?
+
       (@project.engine.drivers.flat_map(&:post_start_commands) +
        @project.engine.extensions.flat_map(&:post_start_commands) +
         @setup_manager.client_post_start_commands).select(&:guest_run)
@@ -202,13 +208,18 @@ module AutoHCK
 
           Thread.exit
         end
-        prepare_machine
+        if pool_only_client?
+          @logger.info("Skipping driver preparation for #{@name} " \
+                       "(role: #{@project.engine.platform_clients.role_for(@name)})")
+        else
+          prepare_machine
+        end
         move_machine_to_pool
       end
 
       configure_machine
       run_post_start_commands
-      add_target_to_project
+      add_target_to_project unless pool_only_client?
     end
 
     def configure(run_only: false)

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -147,7 +147,7 @@ module AutoHCK
     MONITOR_BASE_PORT = 10_000
     VNC_BASE_PORT = 5900
     MAX_RUN_ID = 999
-    MAX_CLIENT_ID = 2
+    MAX_CLIENT_ID = 3
 
     DEFAULT_RUN_OPTIONS = {
       keep_alive: false,

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -147,7 +147,19 @@ module AutoHCK
     MONITOR_BASE_PORT = 10_000
     VNC_BASE_PORT = 5900
     MAX_RUN_ID = 999
-    MAX_CLIENT_ID = 3
+    # https://learn.microsoft.com/en-us/windows-hardware/test/hlk/testref/test-server-configuration
+    # 0 - Studio
+    # 1 - Active Directory (SVVP-only but mandatory)
+    # 2 - SUT / DUT
+    # 3 - Master client / Support client for DUT
+    # 4 - Stress Client 1
+    # 5 - Stress Client 2
+    # 6 - Stress Client 3
+    # 7 - Stress Client 4
+    # 8 - Stress Client 5
+    # 9 - Stress Client 6
+    # 10 - Stress Client 7 (LoadGen supports up to 64 SC machines, but 8 is usually sufficient, QE uses 4)
+    MAX_CLIENT_ID = 10
 
     DEFAULT_RUN_OPTIONS = {
       keep_alive: false,


### PR DESCRIPTION
Add a role field to platform client config. 
WHQL uses dut/support,SVVP uses sut/master(MC)/stress(SC).

Add `ClientRole` and `PlatformClients` to resolve and validate role
combinations. Master/stress clients skip driver install and HLK target
registration but still join the pool.
