### PR TITLE
Make enlightenments_state nilable in HLKPlatform

### DIFF
--- a/lib/models/hlk_platform.rb
+++ b/lib/models/hlk_platform.rb
@@ -52,7 +52,7 @@ module AutoHCK
       const :setupmanager, String
       const :fw_type, String, default: 'uefi'
       const :tpm_state, T::Boolean, default: false
-      const :enlightenments_state, T::Boolean, default: false
+      const :enlightenments_state, T.nilable(T::Boolean)
       const :cpu, T.nilable(String)
       const :clients_options, HLKPlatformClientsOptions, factory: -> { HLKPlatformClientsOptions.new }
       const :st_image, T.nilable(String)


### PR DESCRIPTION
We should not set default to 'false' because platform can be without enlightenments_state but driver with.
In this case we hide driver state.