### PR TITLE
docs: refresh Getting Started, Home, and Image Installation guides

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,6 +1,19 @@
 # Getting Started
 
-There are not so few steps needed to install and set up AutoHCK, First of all, clone AutoHCK and follow the instruction below:
+This guide covers manual setup of AutoHCK on a Linux host. For an automated installation path, see the [AutoHCK-Installer wiki](https://github.com/HCK-CI/AutoHCK-Installer/wiki).
+
+Return to the [documentation map](Home.md) when you need CLI usage or workspace logging details.
+
+## Overview
+
+AutoHCK orchestrates Windows VMs (via QEMU or physical machines), installs HLK/HCK kits, runs WHQL tests, and collects results. A typical first-time workflow:
+
+1. Install host prerequisites and clone dependency repositories.
+2. Configure `config.json` (and optionally `override.json`).
+3. Place Windows and kit ISOs on the host and update `iso.json` / kit JSON files as needed.
+4. Create VM images: `bin/auto_hck install -p <platform>`.
+5. Run tests: `bin/auto_hck test -d <driver> -p <platform> --driver-path <path>`.
+6. Verify output under `<workspace_path>/latest/`.
 
 ## Automatic installation
 
@@ -8,49 +21,225 @@ See [AutoHCK Installer](https://github.com/HCK-CI/AutoHCK-Installer/wiki) for mo
 
 ## Manual installation
 
-  1. Build QEMU from [source](https://github.com/qemu/qemu) or install using your package manager.
-  1. `git clone https://github.com/HCK-CI/extra-software` - AutoHCK will use it as a dependency for image creation.
-  1. `git clone https://github.com/HCK-CI/toolsHCK` - AutoHCK will use it as a dependency for HLK automation in Guest OS.
-  1. Install Ruby version 3.1.0 or 3.3.0. Using [RVM](https://rvm.io/) or your package manager.
-  1. `cd AutoHCK`,  `bundler install` - AutoHCK ruby dependencies.
-  1. Install [slirp4netns](https://github.com/rootless-containers/slirp4netns) v0.4.0 or newer.
+AutoHCK runs on a Linux host. The steps below install host tools, clone dependencies, and prepare configuration before you create VM images.
 
-  1. `git clone https://github.com/HCK-CI/hckfilters` - Filters are fixes for problematic tests.
-  1. `git clone https://github.com/HCK-CI/hlkplaylists` - To run HLK tests with the latest Microsoft compatibility playlist.
-  1. Update configuration files
+1. Clone this repository. Run these commands from a parent directory of your choice (for example `~/HCK-CI/`)
+   ```bash
+   git clone https://github.com/HCK-CI/AutoHCK.git
+   ```
+
+2. Build QEMU from [source](https://github.com/qemu/qemu) or install using your package manager. On Fedora or RHEL:
+
+   ```bash
+   sudo dnf install qemu-kvm qemu-img
+   ```
+
+3. Clone the [extra-software](https://github.com/HCK-CI/extra-software) repository as a sibling of `AutoHCK/` (from the same parent directory where you cloned AutoHCK in step 1):
+
+   ```bash
+   git clone https://github.com/HCK-CI/extra-software.git
+   ```
+
+4. Install Ruby **≥ 3.3.0** (via your package manager or [RVM](https://rvm.io/)). On Fedora or RHEL:
+
+   ```bash
+   sudo dnf install ruby ruby-devel gcc make libyaml-devel openssl-devel
+   ruby --version   # must be ≥ 3.3.0
+   ```
+
+   If `ruby --version` reports below 3.3.0 (common on RHEL 9, Rocky Linux, and AlmaLinux), install Ruby ≥ 3.3.0 with [RVM](https://rvm.io/) or another version manager.
+
+
+5. Clone **`hckfilters` and `hlkplaylists` inside the AutoHCK repo** at `./filters/` and `./playlists/` (see `hcktest.json`). From the AutoHCK repo root:
+
+   ```bash
+   cd AutoHCK
+   git clone https://github.com/HCK-CI/hckfilters.git filters
+   git clone https://github.com/HCK-CI/hlkplaylists.git playlists
+   ```
+
+   Example resulting layout:
+
+   ```
+   HCK-CI/                    # parent directory — name is arbitrary
+   ├── AutoHCK/
+   │   ├── filters/           # → hcktest.json filters_path
+   │   └── playlists/         # → hcktest.json playlists_path
+   └── extra-software/        # → config.json extra_software
+   ```
+
+6. Install Ruby dependencies:
+
+   ```bash
+   bundle install
+   ```
+
+7. Install host tools used by AutoHCK (QEMU networking, ISO handling, and related scripts). On Fedora or RHEL:
+
+   ```bash
+   sudo dnf install -y slirp4netns net-tools ethtool xorriso jq swtpm swtpm-tools
+   slirp4netns --version
+   which ifconfig ethtool xorriso jq
+   command -v swtpm_setup >/dev/null && echo "swtpm OK"
+   ```
+
+8. Configure AutoHCK — see [Configuration](#configuration) below (prefer `override.json`).
 
 ## Configuration
 
-There are two way to configure AutoHCK:
+There are two ways to configure AutoHCK:
 
-  1. Create `override.json` based on `override.json.example` (preferred)
-  2. Edit each configurations JSON files:
-     * `config.json` is the general configuration file which holds the paths to the dependencies stated above.
-     * `lib/engines/hcktest/hcktest.json` is the specific configuration file for the test engine.
-     * `lib/engines/hcktest/platforms/<platform>.json` are set of file with operations systems images configuration.
-     * `lib/engines/hcktest/drivers/<driver>.json` are set of file of drivers information for testing.
-     * `lib/engines/hckinstall/iso.json` list of ISO with information for unattended VM installation.
-     * `lib/engines/hckinstall/hckinstall.json` is the specific configuration file for the install engine.
-     * `lib/engines/hckinstall/kit.json` list of HCK/HLK kits.
+### 1. `override.json` (preferred)
 
-## Additional information
+`override.json` is gitignored (`/override.*`). AutoHCK deep-merges it into any JSON file it loads, keyed by the target file path (for example `config.json` or `lib/setupmanagers/qemuhck/qemu_machine.json`). Values in the override win over the repository defaults; keys you omit are left unchanged.
 
-### Microsoft HCK filters
+Use `--config /path/to/custom.json` to point at a different override file.
 
-Filters are fixes for problematic tests, read more at: [Microsoft HLK Filters](https://docs.microsoft.com/en-us/windows-hardware/test/hlk/user/windows-hardware-lab-kit-filters)
-To run tests with applied filters automatically, get a copy of `UpdateFilters.sql` from [HCK-CI/hckfilters](https://github.com/HCK-CI/hckfilters) and place them inside AutoHCK at `filters/UpdateFilters.sql` .
+#### Create directories
 
-### Microsoft HLK playlists
+`AUTOHCK_DIR` is the path to your AutoHCK clone. Choose any absolute paths for the data directories below. They do not need to sit under `AUTOHCK_DIR` or follow a particular naming scheme — only the values in `override.json` must match where you actually store files.
 
-To run HLK tests with the latest Microsoft compatibility playlist clone [HLK Playlists](https://github.com/HCK-CI/hlkplaylists) inside AutoHCK and rename the directory to playlists, once it's there AutoHCK will look for the right XML playlist file and apply it to the tests.
+```bash
+export AUTOHCK_DIR="/path/to/AutoHCK"
+export ISO_PATH="/path/to/iso"
+export IMAGES_PATH="/path/to/images"
+export WORKSPACE_PATH="/path/to/workspace"
+
+mkdir -p "${ISO_PATH}" "${IMAGES_PATH}" "${WORKSPACE_PATH}"
+```
+
+Example (AutoHCK and data directories under one parent folder):
+
+```bash
+export AUTOHCK_DIR="/home/jane/HCK-CI/AutoHCK"
+export ISO_PATH="/home/jane/HCK-CI/iso"
+export IMAGES_PATH="/home/jane/HCK-CI/images"
+export WORKSPACE_PATH="/home/jane/HCK-CI/workspace"
+
+mkdir -p "${ISO_PATH}" "${IMAGES_PATH}" "${WORKSPACE_PATH}"
+```
+
+#### Copy the template
+
+From the AutoHCK repo root:
+
+```bash
+cd "${AUTOHCK_DIR}"
+cp override.json.example override.json
+```
+
+The example ships compiled-QEMU paths and a Win2019 `iso.json` placeholder. Edit every path for your host before running `install` or `test`.
+
+#### Step 1 — `config.json`
+
+| Key | Where to get the value |
+|-----|------------------------|
+| `iso_path` | Directory for Windows and kit ISO files (`ISO_PATH` above). |
+| `extra_software` | Absolute path to the cloned [extra-software](https://github.com/HCK-CI/extra-software) repo (step 3). |
+| `workspace_path` | Writable directory for run logs and workspaces (`WORKSPACE_PATH` above). |
+| `result_uploaders` | Leave `[]` until you configure [result uploading](#result-uploading). |
+| `windows_password` (optional) | Guest Administrator password. Omit to keep the default value from `config.json`. |
+
+```json
+"config.json": {
+    "iso_path": "/path/to/iso",
+    "extra_software": "/path/to/extra-software",
+    "workspace_path": "/path/to/workspace",
+    "result_uploaders": []
+}
+```
+
+#### Step 2 — `lib/setupmanagers/qemuhck/qemu_machine.json`
+
+Replace the compiled-QEMU paths from `override.json.example` with your host binaries. On Fedora, `qemu_bin` is usually `/usr/bin/qemu-system-x86_64`; on RHEL / CentOS Stream, `/usr/libexec/qemu-kvm`.
+
+```json
+"lib/setupmanagers/qemuhck/qemu_machine.json": {
+    "qemu_bin": "/usr/libexec/qemu-kvm",
+    "qemu_img_bin": "/usr/bin/qemu-img",
+    "ivshmem_server_bin": "",
+    "fs_daemon_bin": "/usr/libexec/virtiofsd",
+    "fs_daemon_share_path": "/path/to/workspace/fs_share",
+    "images_path": "/path/to/images",
+    "fs_test_image": "/path/to/images/filesystem_tests_image.qcow2"
+}
+```
+
+- `qemu_bin` — QEMU system emulator.
+- `qemu_img_bin` — `qemu-img` for disk image operations.
+- `ivshmem_server_bin` — path to `ivshmem-server`; required only for IVSHMEM driver testing. Leave `""` otherwise. Any compatible `ivshmem-server` binary may be used.
+- `fs_daemon_bin` — path to `virtiofsd`; required only for virtiofs driver testing. Leave `""` if you don't have `virtiofsd` and don't want to test the virtiofs driver.
+- `fs_daemon_share_path` — host directory shared into guests (often `${WORKSPACE_PATH}/fs_share`).
+- `images_path` — qcow2 backing images directory (`IMAGES_PATH` above).
+- `fs_test_image` — filesystem test image template; AutoHCK creates it if missing.
+
+#### Complete skeleton (typical manual install)
+
+After editing, a minimal override for the layout in step 5 with distro QEMU on Fedora looks like:
+
+```json
+{
+    "config.json": {
+        "iso_path": "/path/to/iso",
+        "extra_software": "/path/to/extra-software",
+        "workspace_path": "/path/to/workspace",
+        "result_uploaders": []
+    },
+    "lib/setupmanagers/qemuhck/qemu_machine.json": {
+        "qemu_bin": "/usr/bin/qemu-system-x86_64",
+        "qemu_img_bin": "/usr/bin/qemu-img",
+        "ivshmem_server_bin": "",
+        "fs_daemon_bin": "/usr/libexec/virtiofsd",
+        "fs_daemon_share_path": "/path/to/workspace/fs_share",
+        "images_path": "/path/to/images",
+        "fs_test_image": "/path/to/images/filesystem_tests_image.qcow2"
+    },
+    "lib/engines/hckinstall/iso.json": {}
+}
+```
+
+Fill in `iso.json` when you follow [Image Installation](Image-Installation.md) (before `bin/auto_hck install`).
+
+#### Validate
+
+```bash
+jq . "${AUTOHCK_DIR}/override.json" > /dev/null && echo "JSON valid"
+jq -r '."config.json".extra_software' "${AUTOHCK_DIR}/override.json"
+test -x "$(jq -r '."lib/setupmanagers/qemuhck/qemu_machine.json".qemu_bin' "${AUTOHCK_DIR}/override.json")" && echo "qemu OK"
+test -x "$(jq -r '."lib/setupmanagers/qemuhck/qemu_machine.json".qemu_img_bin' "${AUTOHCK_DIR}/override.json")" && echo "qemu-img OK"
+FS_DAEMON="$(jq -r '."lib/setupmanagers/qemuhck/qemu_machine.json".fs_daemon_bin' "${AUTOHCK_DIR}/override.json")"
+[ -n "$FS_DAEMON" ] && test -x "$FS_DAEMON" && echo "virtiofsd OK"
+```
+
+### 2. Direct edit of JSON files
+
+Alternatively, edit each configuration JSON file in the repository:
+
+* `config.json` is the general configuration file which holds the paths to the dependencies stated above.
+* `lib/engines/hcktest/hcktest.json` is the specific configuration file for the test engine.
+* `lib/engines/hcktest/platforms/<platform>.json` are a set of files with operating systems images configuration.
+* `lib/engines/hcktest/drivers/<driver>.json` are a set of files of drivers information for testing.
+* `lib/engines/hckinstall/iso.json` list of ISO with information for unattended VM installation.
+* `lib/engines/hckinstall/hckinstall.json` is the specific configuration file for the install engine.
+* `lib/engines/hckinstall/kits/<kit>.json` list of HCK/HLK kits.
+
+## Microsoft HCK filters
+
+Filters are fixes for problematic tests. See [Microsoft HLK Filters](https://docs.microsoft.com/en-us/windows-hardware/test/hlk/user/windows-hardware-lab-kit-filters).
+
+If you followed [step 5](#manual-installation), `filters/UpdateFilters.sql` is already in place. Otherwise clone [HCK-CI/hckfilters](https://github.com/HCK-CI/hckfilters) to `filters/` at the AutoHCK repo root (path configured in `hcktest.json` → `filters_path`).
+
+## Microsoft HLK playlists
+
+If you followed [step 5](#manual-installation), `playlists/` is already in place. Otherwise clone [HLK Playlists](https://github.com/HCK-CI/hlkplaylists) to `playlists/` at the AutoHCK repo root (path configured in `hcktest.json` → `playlists_path`). See also [Download Windows Hardware Compatibility Playlist](https://learn.microsoft.com/en-us/windows-hardware/test/hlk/#download-windows-hardware-compatibility-playlist). AutoHCK selects the appropriate XML playlist for the kit/platform.
 
 ## Images installation
 
-See [ImageInstallation](Image-Installation.md) for more details
+See [Image Installation](Image-Installation.md) for ISO preparation, answer files, kit configuration, UEFI ISO patching, and the `install` command.
 
 ## Result uploading
 
-AutoHCK supports uploading the results of the tests, (logs, test results and the hckx\hlkx package file), using the supported uploaders by configuring the array field "result_uploader" in the `config.json` file to the desired uploaders for AutoHCK to use, for example, to use dropbox:
+AutoHCK supports uploading the results of the tests, (logs, test results and the hckx\hlkx package file), using the supported uploaders by configuring the `result_uploaders` array in `config.json` to the desired uploaders for AutoHCK to use, for example, to use dropbox:
 
 ```
     "studio_username": "Administrator",

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -5,41 +5,69 @@
 AutoHCK is a tool for automating [HCK](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/windows-hardware-certification-kit)/[HLK](https://docs.microsoft.com/en-us/windows-hardware/test/hlk/), test frameworks for Windows hardware drivers (WHQL certification), doing all the boilerplate steps in the process leaving you with simply choosing which driver you want to test on what OS.
 
 ## What is WHQL
+
 The Windows Hardware Quality Labs (WHQL) certification is intended to help ensure that hardware and drivers for devices meet certain quality and compatibility standards. By obtaining WHQL certification, a device manufacturer is able to demonstrate that their products have been tested and found to be compatible with the Windows operating system.
+
 In general, the WHQL certification process can be helpful for both device manufacturers and users. For manufacturers, obtaining WHQL certification can help to ensure that their products will work properly with the Windows operating system, which can improve the user experience and help to build trust with customers.
+
 For users, the WHQL certification process can help to ensure that the hardware and drivers they are using are of high quality and are compatible with the Windows operating system. This can help to reduce the risk of errors and other problems, and can help to improve the overall stability and performance of the user's system.
+
 Overall, the WHQL certification process can be helpful in ensuring that hardware and drivers for devices are compatible with the Windows operating system and are of high quality. This can benefit both device manufacturers and users.
 
 
 ## Getting Started
 
-See [Getting Started](Getting-Started.md) for more details
+See [Getting Started](Getting-Started.md) for prerequisites, dependency clones, configuration, and first-time validation steps.
 
 ## Usage
 
-Once everything is installed and configured, run `./bin/auto_hck` with these parameters:
+Once everything is installed and configured, run AutoHCK from the repository root:
 
+```bash
+bin/auto_hck <command> [options]
 ```
+
+For all options, run:
+
+```bash
+bin/auto_hck --help
+bin/auto_hck test --help
+bin/auto_hck install --help
+```
+
+### CLI reference
+
+The following matches `bin/auto_hck --help` (common options plus subcommand summaries):
+
+```text
 Usage: auto_hck.rb [common options] <command> [command options]
 
+        --share-on-host-path <path>  For using Transfer Network specify the directory to share on host machine
         --verbose                    Enable verbose logging
         --config <override.json>     Path to custom override.json file
         --client_world_net           Attach world bridge to clients VM
         --client-ctrl-net-dev <client-ctrl-net-dev>
                                      Client VM control network device (make sure that driver is installed)
+        --attach-debug-net           Attach debug network to all VMs
         --id <id>                    Set ID for AutoHCK run
     -v, --version                    Display version information and exit
-        --share-on-host-path <path>  For using Transfer Network specify the directory to share on host machine
+    -w <path>                        Internal use only
+        --whiteboard <text>          Custom text logged, added to HTML results and JUnit properties
     -h, --help                       Show this message
 Usage: auto_hck.rb test [test options]
 
     -p, --platform <platform_name>   Platform for run test
     -d, --drivers <drivers_list>     List of driver for run test
         --driver-path <driver_path>  Path to the location of the driver wanted to be tested
+        --supplemental-path <supplemental_path>
+                                     Path to the supplemental content folder (e.g. for README)
+        --package-with-driver [package_action]
+                                     Include driver files in HLKX package (requires --driver-path)
+                                     Use --package-with-driver or --package-with-driver=keep to include driver with original signature
+                                     Use --package-with-driver=unsigned to remove signature from the driver before including
     -c, --commit <commit_hash>       Commit hash for CI status update
-        --diff <diff_file>           Path to text file containing a list of changed source files
         --svvp                       Run SVVP tests for specified platform instead of driver tests
-        --dump                       Create machines snapshots and generate scripts for run it manualy
+        --dump                       Create machines snapshots and generate scripts for run it manually
         --gthb_context_prefix <gthb_context_prefix>
                                      Add custom prefix for GitHub CI results context
         --gthb_context_suffix <gthb_context_suffix>
@@ -49,7 +77,7 @@ Usage: auto_hck.rb test [test options]
                                      Use custom user text playlist
         --reject-test-names <reject_test_names>
                                      Use custom CI text ignore list
-        --triggers <triggers_file>   Path to text file containing triggers
+        --enable-vbs                 Enable VBS state for clients
         --reject-report-sections <reject_report_sections>
                                      List of section to reject from HTML results
                                      (use "--reject-report-sections=help" to list sections)
@@ -58,7 +86,33 @@ Usage: auto_hck.rb test [test options]
                                      Works only with custom user text playlist.
                                      Test results table can be broken. (experimental)
         --manual                     Run AutoHCK in manual mode
+        --auto-manual                Run AutoHCK in normal mode and switch to manual mode only when failure is detected
         --package-with-playlist      Load playlist into HLKX project package
+        --tag-suffix <tag_suffix>    Add custom suffix to HCK-CI tag to prevent name conflicts when using shared controller
+        --fs-test-image-format <fs_test_image_format>
+                                     Filesystem test image format (qcow2/raw). Default is qcow2.
+                                     Has effect only when testing storage drivers.
+        --extensions <extensions_list>
+                                     List of extensions for run test
+        --net-test-speed <net_test_speed>
+                                     Network test speed (in Mbps). Default is 10000.
+                                     Has effect only when testing virtio-net-pci network device.
+        --auto-retry-failed-tests <auto_retry_failed_tests>
+                                     Automatically retry failed tests specified number of times to mitigate transient failures.
+                                     Use with caution, it can hide real issues if used excessively.
+                                     Results files (like HLKX, results.html, results.xml) contain information about test objects,
+                                     so if a failed test is retried and passed on retry, it will be marked as passed in results files,
+                                     without any indication that it was failed at the beginning. It is recommended to check logs for
+                                     failed tests if this option is used.
+                                     Possible values:
+                                       -1 - retry indefinitely until all tests pass;
+                                       0 - do not retry failed tests;
+                                       N - retry failed tests up to N times.
+        --query <query>              Run a query and exit without starting a test session.
+                                     Supported queries: images-names
+        --query-output-file <path>   Write query output to the specified file in addition to the log
+        --session <path>             Bring up a previous test session from its workspace path
+        --latest-session             Bring up the most recent test session
     -h, --help                       Show this message
 Usage: auto_hck.rb install [install options]
 
@@ -68,40 +122,67 @@ Usage: auto_hck.rb install [install options]
         --skip_client                Skip client images installation
     -d, --drivers <drivers_list>     List of driver attach in install
         --driver-path <driver_path>  Path to the location of the driver wanted to be installed
+        --no-reboot-after-bugcheck   Keep system in crashed state after crash for debugging (disables automatic reboot)
+    -h, --help                       Show this message
+```
+
+### Selective CI (`triggers_check`)
+
+`--diff` and `--triggers` are **not** on `bin/auto_hck test`. Use the standalone helper to decide whether CI should run tests:
+
+```bash
+bin/triggers_check --diff /path/to/diff.txt --triggers /path/to/triggers.yml
+```
+
+Exit code `0` means at least one trigger matched (run tests); exit code `1` means skip tests.
+
+```text
+Usage: triggers_check [--help] <options>
+
+        --debug                      Printing debug information (optional)
+        --diff <diff_file>           Path to text file containing a list of changed source files
+        --triggers <trigger_file>    Path to text file containing a list of triggers
+        --trigger_keys <trigger_keys>
+                                     List of trigger keys
     -h, --help                       Show this message
 ```
 
 ### Dump mode
-(make sure that driver is installed)
+
 In dump mode, AutoHCK generates bash script files for each VM with all preparation steps. You can edit these files, update the QEMU command line, and then run it.
 
 ### Manual mode
 
-In manual mode, AutoHCK performs the following steps:
-   - Run VMs
-   - Configure HLK environment (if driver binary present)
-   - Run selected tests (if driver binary present)
-   - Stop automatic test runs and start waiting for a manual exit
-   - Stop VMs and save all run logs
+In manual mode (`--manual`), AutoHCK performs the following steps:
+
+- Run VMs
+- Configure HLK environment (if driver binary present)
+- Run selected tests (if driver binary present)
+- Stop automatic test runs and start waiting for a manual exit
+- Stop VMs and save all run logs
 
 ### Examples
 
-```
-bin/auto_hck test --drivers Balloon --platform Win10x86 --driver-path /home/hck-ci/balloon/win10/x86
-bin/auto_hck test --drivers NetKVM --platform Win10x64 --driver-path /home/hck-ci/workspace --diff /path/to/diff.txt
-bin/auto_hck test --drivers viostor --platform Win10x64 --driver-path /home/hck-ci/viostor --diff /path/to/diff.txt -c ec3da560827922e5a82486cf19cd9c27e95455a9
-bin/auto_hck test --svvp --platform Win10x64 --driver-path /home/hck-ci/virtio-drv
-bin/auto_hck test -d NetKVM -p Win10x64 --driver-path /home/hck-ci/virtio-drv --manual
-bin/auto_hck test -d NetKVM -p Win10x64 --manual
+```bash
+bin/auto_hck install -p Win11_25H2x64
 bin/auto_hck install -p Win2019x64 --force
+bin/auto_hck test -d Balloon -p Win10_2004x86_bios --driver-path /path/to/driver
+bin/auto_hck test -d NetKVM -p Win10_2004x64 --driver-path /path/to/driver -c ec3da560827922e5a82486cf19cd9c27e95455a9
+bin/auto_hck test --svvp -p Win10_2004x64 --driver-path /path/to/virtio-drv
+bin/auto_hck test -d NetKVM -p Win10_2004x64 --driver-path /path/to/driver --manual
+bin/auto_hck test -d NetKVM -p Win10_2004x64 --manual
+bin/auto_hck test --latest-session
+bin/triggers_check --diff /path/to/diff.txt --triggers /path/to/triggers.yml
 ```
 
 ### Workspace
 
 When starting AutoHCK a session workspace will be created inside the workspace directory configured in `config.json` at the path:
-  + in test mode: `workspace/[engine-type]/[setup-manager]/[devices-list]-[platform]/[timestamp]/`
-  + in test svvp mode: `workspace/[engine-type]/[setup-manager]/svvp-[platform]/[timestamp]/`
-  + in install mode: `workspace/[engine-type]/[setup-manager]/[platform]/[timestamp]/`
+  + in test mode: `workspace/[engine-type]/[devices-list]-[platform]/[timestamp]/`
+  + in test svvp mode: `workspace/[engine-type]/svvp-[platform]/[timestamp]/`
+  + in install mode: `workspace/[engine-type]/[platform]/[timestamp]/`
+
+A `latest` symlink under `workspace/` points at the most recent session directory.
 
 Inside AutoHCK will save the following files:
 * qcow2 snapshots of the backing setup images: `[filename]-snapshot.qcow2`

--- a/docs/Image-Installation.md
+++ b/docs/Image-Installation.md
@@ -1,6 +1,8 @@
 # AutoHCK image creation
 
-AutoHCK is a tool for automating HCK/HLK testing, doing all the boilerplate steps in the process leaving you with simply choosing which driver you want to test on what OS.
+AutoHCK automates HCK/HLK testing, including unattended Windows installation and HLK kit setup on studio and client VMs.
+
+See [Getting Started](Getting-Started.md) for host prerequisites and [Home](Home.md) for the `install` command overview.
 
 ## Manual installation
 
@@ -8,16 +10,24 @@ The install engine ships PowerShell setup scripts under `lib/engines/hckinstall/
 
 For more context on the original upstream workflow, see [HLK-Setup-Scripts](https://github.com/HCK-CI/HLK-Setup-Scripts).
 
-Images should be copied to the images directory as configured in the `config.json` file.
+Finished qcow2 images are stored under `images_path` in `lib/setupmanagers/qemuhck/qemu_machine.json`. 
 
 ## Automatic installation preparation
 
 ### Windows ISO preparation
 
-1. Create a directory for all ISO image storing.
-2. Write this path into the `config.json` file (see AutoHCK configuration section).
-3. Download ISO which is needed for a specific platform installation and copy it into the created directory.
-4. Add information about this iso into `lib/engines/hckinstall/iso.json` (see AutoHCK configuration section).
+If you configured `iso_path` in [Getting Started](Getting-Started.md#1-overridejson-preferred), the directory already exists. Otherwise create it and set `config.json` → `iso_path` first.
+
+1. **Obtain a Windows ISO** — use an ISO you already have, or download one from Microsoft ([Evaluation Center](https://www.microsoft.com/evalcenter/), [Software Download](https://www.microsoft.com/en-in/software-download)).
+
+2. **Pick the right Windows release** for the platform you will install (`-p <platform>`). AutoHCK installs two kinds of VMs — a **studio** (HLK server) and **clients** (test machines). Each needs a Windows ISO entry in `iso.json`:
+   - **Clients** — see `client_iso` in `lib/engines/hcktest/platforms/<platform>.json`.
+   - **Studio** — see `studio_platform` in `lib/engines/hckinstall/kits/<kit>.json` (use the `kit` named in the platform file).
+
+   Example: for `-p Win2019x64`, both point to `Win2019x64`, so you need a **Windows Server 2019** ISO with an `iso.json` entry under that name.
+
+3. **Copy the ISO into `iso_path`.** Keep the original filename; you will use the same name in `iso.json` → `path` ([AutoHCK configuration](#autohck-configuration)).
+
 
 ### Bundled install engine directories
 
@@ -39,18 +49,19 @@ Base names in `hckinstall.json` are `autounattend.xml` and `unattend.xml`; the e
 
 #### Kit installers
 
-Kit ISOs can also be placed on the ISO path configured in `config.json` (see `kit.json` / platform kit definitions and download URLs).
+Each HLK/HCK kit has its own JSON file under `lib/engines/hckinstall/kits/<kit>.json` (for example `HLK11_24H2.json`). Kit ISO installers can also be placed under `iso_path` when downloaded locally (see download URLs in each kit file).
 
 ### Windows ISO preparation for installation in UEFI mode
 
-In case when UEFI firmware, not BIOS is booted, the Windows installer always asks to press any key to boot from CD/DVD. AutoHCK can't do this in the proper way.
+When UEFI firmware (not BIOS) is used, the Windows installer prompts to press any key to boot from CD/DVD. AutoHCK cannot send that key automatically.
 
 So you should patch ISO and replace UEFI boot loader code. By default, ISO uses the EFI boot code from efisys.bin. There is also an efisys_noprompt.bin boot code that skips the prompt step.
 
-Please use the following commands to create a new ISO:
+Please use the following commands to create a patched ISO. Replace `original.iso` with your downloaded Windows ISO; `-o new.iso` writes the patched copy (use any output filename — it must match the `path` in `iso.json`).
 
-using mkisofs:
-```
+Using mkisofs:
+
+```bash
 mount original.iso /mnt
 mkisofs \
     -iso-level 4 \
@@ -69,10 +80,12 @@ mkisofs \
     -b "efi/microsoft/boot/efisys_noprompt.bin" \
     -o new.iso \
     /mnt
+umount /mnt
 ```
 
-using xorriso:
-```
+Using xorriso:
+
+```bash
 mount original.iso /mnt
 xorriso -as mkisofs \
     -iso-level 4 \
@@ -90,78 +103,92 @@ xorriso -as mkisofs \
     -b "efi/microsoft/boot/efisys_noprompt.bin" \
     -o new.iso \
     /mnt
-
 umount /mnt
 ```
 
 ### AutoHCK configuration
 
-Configure AutoHCK to have all information for building VM images. Edit the next files according to templates present in each file.
+Configure AutoHCK with the information needed to build VM images. Edit the following files according to the templates in each file.
 
-1. `lib/engines/hckinstall/iso.json` - contains information about Windows ISO for each HCK/HLK platform. Each platform entry should be configured as follows:
-   - **platform_name** (top-level key) - The platform name should be the same as referenced in platform configuration files via `client_iso` field, or in kit JSON files via `studio_platform` field.
-   - **path** - Path relative to `iso_path` option in the config file to the corresponding ISO image.
-   - **studio** section (required for platforms used as studio VMs) - Contains studio-specific configuration:
-      * **windows_image_names** - Image name from `install.wim` file in ISO for the studio VM.
-      * **product_key** - Valid product key for the studio Windows image.
-   - **client** section (required for platforms used as client VMs) - Contains client-specific configuration:
-      * **windows_image_names** - Image name from `install.wim` file in ISO for the client VM.
-      * **product_key** - Valid product key for the client Windows image.
+1. `lib/engines/hckinstall/iso.json` holds information about the Windows ISO for each HCK/HLK platform. Each platform entry uses the following fields:
+   - **platform_name** (top-level key) must match the name referenced in platform configuration files via the `client_iso` field, or in kit JSON files via the `studio_platform` field.
+   - **path** is the path relative to `iso_path` in `config.json` to the corresponding ISO file.
+   - **studio** (required for platforms used as studio VMs) contains studio-specific settings:
+      * **windows_image_names** is the image name from `install.wim` in the ISO for the studio VM.
+      * **product_key** is a valid product key for the studio Windows image.
+   - **client** (required for platforms used as client VMs) contains client-specific settings:
+      * **windows_image_names** is the image name from `install.wim` in the ISO for the client VM.
+      * **product_key** is a valid product key for the client Windows image.
 
-   **Note:** Server platforms (e.g., Win2022x64, Win2019x64) typically require **both** `studio` and `client` sections because they can be used in either role. Client-only platforms (e.g., Win10_22H2x86) only require the `client` section since they are never used as studio VMs.
+   **Note:** Server platforms (e.g. `Win2022x64`, `Win2019x64`) typically require **both** `studio` and `client` sections because they can be used in either role. Client-only platforms (e.g. `Win10_22H2x86`) require only the `client` section.
 
-   To get a list of available Windows image names from an ISO:
-   * On Windows: `dism /get-wiminfo /wimfile:D:\sources\install.wim`
-   * On Linux: `wiminfo /mnt/sources/install.wim` (requires wimlib)
+   To list available Windows image names from an ISO:
+   * On Windows, run `dism /get-wiminfo /wimfile:D:\sources\install.wim`.
+   * On Linux, install [wimlib](https://wimlib.net/) first, then mount the ISO and list image names. Replace `/path/to/windows.iso` in the command with your ISO file (for example, a file under `iso_path`). Some ISOs use `sources/install.esd` instead of `install.wim`; substitute that path if needed (`wimlib-imagex` supports both).
+
+     ```bash
+     sudo mkdir -p /mnt/winiso
+     sudo mount -o loop,ro /path/to/windows.iso /mnt/winiso
+     wimlib-imagex info /mnt/winiso/sources/install.wim | grep '^Name:' | sed 's/^Name:[[:space:]]*//'
+     sudo umount /mnt/winiso
+     ```
+
 
    Generic product keys can be found at [KMS Client Activation Keys](https://learn.microsoft.com/en-us/windows-server/get-started/kms-client-activation-keys).
 
    **Example configurations:**
 
-   Server platform with both studio and client sections:
-   ```json
-   "Win2022x64": {
-     "path": "en-us_windows_server_2022_x64_dvd_620d7eac_uefi.iso",
-     "studio": {
-       "windows_image_names": "Windows Server 2022 SERVERSTANDARD",
-       "product_key": "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
-     },
-     "client": {
-       "windows_image_names": "Windows Server 2022 SERVERDATACENTER",
-       "product_key": "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
+   * Server platform with both studio and client sections:
+
+     ```json
+     {
+       "Win2022x64": {
+         "path": "en-us_windows_server_2022_x64_dvd_620d7eac_uefi.iso",
+         "studio": {
+           "windows_image_names": "Windows Server 2022 SERVERSTANDARD",
+           "product_key": "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
+         },
+         "client": {
+           "windows_image_names": "Windows Server 2022 SERVERDATACENTER",
+           "product_key": "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
+         }
+       }
      }
-   }
-   ```
+     ```
 
-   Client-only platform with just client section:
-   ```json
-   "Win10_22H2x86": {
-     "path": "en-us_windows_10_business_editions_version_22h2_updated_march_2025_x86_dvd_a4d0e05b.iso",
-     "client": {
-       "windows_image_names": "Windows 10 Enterprise",
-       "product_key": "BBBBB-BBBBB-BBBBB-BBBBB-BBBBB"
+   * Client-only platform with just client section:
+
+     ```json
+     {
+       "Win10_22H2x86": {
+         "path": "en-us_windows_10_business_editions_version_22h2_updated_march_2025_x86_dvd_a4d0e05b.iso",
+         "client": {
+           "windows_image_names": "Windows 10 Enterprise",
+           "product_key": "BBBBB-BBBBB-BBBBB-BBBBB-BBBBB"
+         }
+       }
      }
-   }
-   ```
+     ```
 
-2. `lib/engines/hckinstall/hckinstall.json` - contains the specific configuration for the install engine. The following fields should be configured:
-   - **answer_files** (_advanced_) - list of answer file *base names* (without `.in` / disk-layout suffixes) for automatic Windows installation. Templates live under `lib/engines/hckinstall/answer-files/`; see the Answer files subsection under [Bundled install engine directories](#bundled-install-engine-directories).
-   - **install_timeout** (_advanced_) - timeout (seconds) before an install is treated as failed (covers studio and client flow as configured by the engine).
+2. `lib/engines/hckinstall/hckinstall.json` contains settings for the install engine. You may override the following fields:
+   - **answer_files** (_advanced_) is a list of answer file *base names* (without `.in` or disk-layout suffixes) used for unattended Windows installation. Templates live under `lib/engines/hckinstall/answer-files/`; see the Answer files subsection under [Bundled install engine directories](#bundled-install-engine-directories).
+   - **install_timeout** (_advanced_) is the timeout in seconds before an install is treated as failed. It covers the studio and client flows together.
 
-During `install`, AutoHCK copies bundled scripts, merges extra software and generated `args.ps1`, builds `setup-studio.iso` / `setup-client.iso` from that tree, and attaches them to the VMs. HLK kit **ISO** installers are stored under `iso_path` (for example `HLK11_24H2Setup.iso`) when downloaded so later runs can reuse them; **EXE** installers are downloaded into the workspace copy for each run.
+   During `install`, AutoHCK copies bundled scripts, merges extra software and generated `args.ps1`, builds `setup-studio.iso` / `setup-client.iso`, and attaches them to the VMs. HLK kit **ISO** installers are stored under `iso_path` (for example `HLK11_24H2Setup.iso`) when downloaded so later runs can reuse them; **EXE** installers are downloaded into the workspace copy for each run.
 
-3. `config.json` - contains the general AutoHCK configuration. The following fields should be configured:
-   - **iso_path** - absolute path to the directory where ISO stored.
+3. `config.json` holds the general AutoHCK configuration. Configure the following field:
+   - **iso_path** is the absolute path to the directory where ISOs are stored.
 
-4. `lib/engines/hckinstall/kit.json` - contains information about each HCK/HLK kit. The following fields should be configured:
-   - **kit** - The kit name should be the same as in the `platforms.json` file.
-   - **download_url** - contains the URL for download the kit online installer.
+4. `lib/engines/hckinstall/kits/<kit>.json` defines one HCK/HLK kit per file (for example `HLK2022.json`, `HLK11_25H2.json`). The **`kit`** field in `lib/engines/hcktest/platforms/<platform>.json` must match the filename (without `.json`). Each kit file uses these fields:
+   - **name** is the kit identifier (same as the filename stem).
+   - **download_url** is the URL used to download the kit online installer.
+   - **sha256** is the expected installer checksum.
+   - **studio_platform** is the platform name for the studio VM Windows image. It must exist in `iso.json` with a `studio` section, and in `lib/engines/hcktest/platforms/`.
+   - **extra_software** lists optional packages from the extra-software repository that are installed during studio setup.
 
-5. `lib/engines/hckinstall/studio_platform.json` - contains information on which platform should be used for each HCK/HLK kit. The following fields should be configured:
-   - **kit** - The kit name should be the same as in the `platforms.json` file.
-   - **platform_name** - The platform name for Studio VM should be the same as in the `platforms.json` file.
+5. `lib/engines/hcktest/platforms/<platform>.json` links a test platform to a kit, client ISO, backing images, and setup manager. The **`kit`** field must match a file in `lib/engines/hckinstall/kits/`, and **`client_iso`** must match a top-level key in `iso.json`.
 
-6. `lib/setupmanagers/<setup_manager>/<setup_manager>.json` - contains information for specific setup manager. Please edit the setup manager which you need. Existing setup managers config:
+6. `lib/setupmanagers/<setup_manager>/<setup_manager>.json` contains settings for a setup manager backend. Edit the file for the backend you use. Existing configs are:
    - `lib/setupmanagers/physhck/physhck.json`
    - `lib/setupmanagers/qemuhck/qemu_machine.json`
 
@@ -171,28 +198,27 @@ Notes:
 
 ### Extra software installation
 
-The `extra_software` option can be specified in the following files:
-  - `drivers.json` - will be used in test mode only
-  - `lib/engines/hckinstall/kit.json` - will be used in install mode only
-  - `lib/engines/hcktest/<paltform>.json` - will be used in install and test modes
+The `extra_software` option can be set in the following files:
+  - `lib/engines/hcktest/drivers/<driver>.json` — packages listed here are installed in test mode only.
+  - `lib/engines/hckinstall/kits/<kit>.json` — packages listed here are installed in install mode only.
+  - `lib/engines/hcktest/platforms/<platform>.json` — packages listed here are installed in both install and test modes.
 
-According to the file, the software will be installed during image creating (install mode) or during driver testing (test mode)
+According to the file, the software is installed during image creation (install mode) or during driver testing (test mode).
 
 ## Automatic installation
 
-To run installation use the `install` AutoHCK command-line command. AutoHCK will create 3 images (studio and 2 clients) and perform the installation.
+AutoHCK creates a studio image and client images for the selected platform (typically two clients). If a studio image already exists, it is reused unless `--force` is specified.
 
-In case when studio image exists, it will be reused. To recreate studio image use `--force` option
+```bash
+bin/auto_hck install -p Win10_2004x86_bios
+bin/auto_hck install -p Win2019x64 --force
+```
 
-### Examples
-```
-bin/ns bin/auto_hck install -p Win10_2004x86
-bin/ns bin/auto_hck install -p Win2019x64 --force
-```
+**Verify success:** install log in `<workspace_path>/hckinstall/<platform>/<timestamp>/<platform>.log`; backing qcow2 files under `qemu_machine.json` → `images_path` match names in the platform JSON.
 
 ## Related information
 
 Automatic installation is performed by using answer files. This is Windows's ability to install and configure the system from scratch. See the MSDN articles for more details:
 
-   - [Automating Windows setup](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/automate-windows-setup)
-   - [Automate Windows configuration](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs)
+- [Automating Windows setup](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/automate-windows-setup)
+- [Automate Windows configuration](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs)


### PR DESCRIPTION
Refresh the core setup and usage docs with step-by-step manual installation guidance, a structured override.json workflow, and corrected configuration references (kits/<kit>.json, qemu_machine.json paths).

- Getting Started — Adds an overview workflow, Fedora/RHEL prerequisite commands, dependency layout (filters/, playlists/, sibling repos), and a detailed override.json guide with validation commands; updates Ruby requirement to ≥ 3.3.0.

- Home — Syncs the CLI reference with current bin/auto_hck options, documents triggers_check for selective CI, fixes workspace path layout, and updates examples to real platform names.

- Image Installation — Expands ISO/kit configuration guidance, fixes kit file paths, improves UEFI ISO patching examples, and corrects the install platform example (Win10_2004x86_bios).