### PR TITLE
functest: add select_test_names/reject_test_names filtering support

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -17,8 +17,12 @@ The functest engine runs JSON-driven functional tests against a Windows client V
 | `--driver-path <path>` | Host path to the driver package directory; required when drivers are configured |
 | `--category <suite>` | Run a named test suite; `<suite>` is the suite name from `lib/engines/functest/tests/suites/<suite>.json` |
 | `--testcase <names>` | Comma-separated list of test case names to run (e.g. `driver_sign_check,balloon/balloon_service`) |
+| `--select-test-names <file>` | Path to a text file (one test name per line); only tests whose name appears in the file are kept |
+| `--reject-test-names <file>` | Path to a text file (one test name per line); tests whose name appears in the file are skipped. Overrides the suite's own `reject_test_names`, if any. |
 
 Exactly one of `--category` or `--testcase` is required. All common options (`--verbose`, `--config`, `--id`, etc.) apply as documented in [Home](Home.md).
+
+`--select-test-names`/`--reject-test-names` are the same flags used by the `hcktest` engine; the "test name" they match against is the test case identifier as written in `--testcase`/a suite's `tests` array (e.g. `balloon/balloon_service`), not the `name` field inside the test case's own JSON.
 
 ### Examples
 
@@ -46,6 +50,35 @@ For test cases in subdirectories, use the relative path from `lib/engines/functe
 
 ```bash
 --testcase balloon/balloon_service,driver_sign_check
+```
+
+#### Narrow down a suite
+
+Given a suite with many tests, run only a subset of them, or skip a few, without editing the suite file or hand-listing everything via `--testcase`:
+
+```bash
+./bin/auto_hck functest \
+  -p Win2025x64_gui \
+  -d Balloon \
+  --driver-path /path/to/balloon/driver \
+  --category balloon_driver_tests \
+  --select-test-names /path/to/select_names.txt
+```
+
+```bash
+./bin/auto_hck functest \
+  -p Win2025x64_gui \
+  -d Balloon \
+  --driver-path /path/to/balloon/driver \
+  --category balloon_driver_tests \
+  --reject-test-names /path/to/reject_names.txt
+```
+
+Where each file contains one test name per line, e.g.:
+
+```
+balloon/balloon_service
+driver_update
 ```
 
 ## Directory Layout
@@ -85,6 +118,7 @@ A suite is an ordered list of test case references, plus optional metadata. Suit
 | `tests` | Yes | Ordered list of test case names to execute |
 | `requirements.drivers` | No | Informational only — not enforced at runtime |
 | `requirements.platforms` | No | Informational only — not enforced at runtime |
+| `reject_test_names` | No | Test case names to always skip when running this suite. Ignored if `--reject-test-names` is passed on the CLI. |
 
 ### Example
 

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -96,18 +96,62 @@ module AutoHCK
     end
 
     def load_tests(loader)
+      names, static_reject_names = test_names_and_static_rejects(loader)
+
+      names = apply_select_test_names(names)
+      names = apply_reject_test_names(names, static_reject_names)
+
+      names.map { |test_name| loader.load_test(test_name) }
+    end
+
+    # Returns the ordered list of test names to load, plus the suite's own
+    # static reject list (empty when running via --testcase, since there is
+    # no suite in that case).
+    def test_names_and_static_rejects(loader)
       test_options = @project.options.test
       if test_options.category
         suite = loader.load_suite(test_options.category)
         @logger.info("Loaded test suite: #{suite.name}")
-        loader.load_suite_tests(suite)
+        [suite.tests, suite.reject_test_names]
       elsif test_options.testcase
-        test_options.testcase.split(',').map do |test_name|
-          loader.load_test(test_name.strip)
-        end
+        [test_options.testcase.split(',').map(&:strip), []]
       else
         raise AutoHCKError, 'Functest requires --category or --testcase'
       end
+    end
+
+    # Reads a text file of test names, one per line.
+    def read_test_names_file(path)
+      raise AutoHCKError, "Test names file not found: #{path}" unless File.exist?(path)
+
+      File.readlines(path, chomp: true).map(&:strip).reject(&:empty?)
+    end
+
+    # --select-test-names <file>: keep only tests whose name appears in the file,
+    # preserving the original order. No-op when the option is not set.
+    def apply_select_test_names(names)
+      select_file = @project.options.test.select_test_names
+      return names unless select_file
+
+      select_names = read_test_names_file(select_file)
+      selected = names & select_names
+
+      @logger.info("Applying custom selected test names: #{selected.length} of #{names.length} test(s) selected")
+      selected
+    end
+
+    # --reject-test-names <file> takes precedence over the suite's own static
+    # reject_test_names list; if neither is present, nothing is rejected.
+    def apply_reject_test_names(names, static_reject_names)
+      reject_file = @project.options.test.reject_test_names
+      reject_names = reject_file ? read_test_names_file(reject_file) : static_reject_names
+      return names if reject_names.empty?
+
+      remaining = names - reject_names
+      rejected_count = names.length - remaining.length
+      @logger.info("Applying custom rejected test names: #{rejected_count} of #{names.length} test(s) rejected") \
+        if rejected_count.positive?
+      remaining
     end
 
     # Loads Models::Driver objects for the drivers listed on the CLI, skipping

--- a/lib/engines/functest/suite.rb
+++ b/lib/engines/functest/suite.rb
@@ -21,6 +21,7 @@ module AutoHCK
       const :test_system_ref, T.nilable(String)
       const :tests, T::Array[String]
       const :requirements, T.nilable(SuiteRequirements)
+      const :reject_test_names, T::Array[String], default: []
     end
   end
 end


### PR DESCRIPTION
Reuses hcktest's --select-test-names/--reject-test-names CLI flags to narrow a --category suite (or --testcase list) without editing the suite file. Also add reject_test_names field on the Suite JSON; the CLI flag overrides the suite's list when both are present.