### PR TITLE
VIRTWINKVM-2236: Extend test replacment options

### DIFF
--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -71,7 +71,7 @@ module AutoHCK
         client = @project.setup_manager.run_functest_client(scope, client_name)
         client.prepare_machine
 
-        @executor = Functest::TestExecutor.new(@project, client.tools, client.name,
+        @executor = Functest::TestExecutor.new(@project, client,
                                                default_timeout: @config['default_timeout'])
         setup_test_context(@executor.context)
         summary = @executor.execute_tests(tests)

--- a/lib/engines/functest/test_context.rb
+++ b/lib/engines/functest/test_context.rb
@@ -6,10 +6,11 @@ module AutoHCK
     class TestContext
       attr_reader :logger, :project
 
-      def initialize(project)
+      def initialize(project, replacement_map)
         @project = project
         @logger = project.logger
-        @replacement_map = ReplacementMap.new
+        @replacement_map = ReplacementMap.new(replacement_map)
+        @replacement_map.each { |placeholder, value| @logger.debug("Initial variable '#{placeholder}' = '#{value}'") }
         @start_time = Time.now
       end
 

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -12,13 +12,13 @@ module AutoHCK
         @test_results ||= @results.map { |r| Models::TestResult.from_functest(r) }
       end
 
-      def initialize(project, tools, machine_name, default_timeout:)
+      def initialize(project, client, default_timeout:)
         @project = project
-        @tools = tools
-        @machine_name = machine_name
+        @tools = client.tools
+        @machine_name = client.name
         @logger = project.logger
-        @context = TestContext.new(project)
-        @step_handler = StepHandler.new(project, tools, machine_name, @context,
+        @context = TestContext.new(project, client.replacement_map)
+        @step_handler = StepHandler.new(project, @tools, @machine_name, @context,
                                         default_timeout: default_timeout)
         @results = []
       end

--- a/lib/engines/functest/tests/cases/balloon/balloon_service.json
+++ b/lib/engines/functest/tests/cases/balloon/balloon_service.json
@@ -11,16 +11,6 @@
             "timeout": 30
         },
         {
-            "desc": "Upload balloon driver package (contains blnsvr.exe)",
-            "files_action": [
-                {
-                    "local_path": "@driver_path@",
-                    "remote_path": "C:\\AutoHCK\\balloon_pkg",
-                    "direction": "local-to-remote"
-                }
-            ]
-        },
-        {
             "desc": "Install balloon service (blnsvr.exe -i)",
             "guest_run_file": "lib/engines/functest/tests/scripts/balloon/install_balloon_service.ps1",
             "expected_output_contains": "Balloon service install command executed",
@@ -39,7 +29,7 @@
         },
         {
             "desc": "Uninstall balloon service (blnsvr.exe -u)",
-            "guest_run": "$blnsvr = Get-ChildItem -Recurse C:\\AutoHCK\\balloon_pkg -Filter blnsvr.exe | Select-Object -First 1; & $blnsvr.FullName -u; Write-Output 'PASS: Balloon service uninstalled'",
+            "guest_run": "$blnsvr = Get-ChildItem -Recurse '@driver_dir@' -Filter blnsvr.exe | Select-Object -First 1; & $blnsvr.FullName -u; Write-Output 'PASS: Balloon service uninstalled'",
             "expected_output_contains": "PASS:",
             "timeout": 30
         },

--- a/lib/engines/functest/tests/scripts/balloon/install_balloon_service.ps1
+++ b/lib/engines/functest/tests/scripts/balloon/install_balloon_service.ps1
@@ -2,7 +2,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$blnsvr = Get-ChildItem -Recurse C:\AutoHCK\balloon_pkg -Filter blnsvr.exe |
+$blnsvr = Get-ChildItem -Recurse '@driver_dir@' -Filter blnsvr.exe |
     Select-Object -First 1
 
 if (-not $blnsvr) {

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -37,7 +37,7 @@ module AutoHCK
         @playlist = Playlist.new(client, project, target, tools, @client.kit)
         @tests = T.let([], T::Array[Models::HLK::Test])
         @test_results = []
-        @replacement_map = ReplacementMap.new({ '@workspace@' => @project.workspace_path })
+        @replacement_map = @project.project_replacement_map
       end
 
       sig { params(updated_tests: T::Array[Models::HLK::Test]).returns(T::Array[Models::HLK::Test]) }

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -14,7 +14,8 @@ module AutoHCK
     attr_reader :config, :logger, :timestamp, :setup_manager, :engine, :id,
                 :workspace_path, :result_uploader, :engine_tag,
                 :engine_platform, :engine_type, :options, :extra_sw_manager,
-                :run_terminated, :engine_name, :string_log, :status, :whiteboard
+                :run_terminated, :engine_name, :string_log, :status, :whiteboard,
+                :project_replacement_map
 
     def apply_json_override
       Json.update_json_override(@options.common.config) unless @options.common.config.nil?
@@ -29,7 +30,8 @@ module AutoHCK
       init_multilog(@options.common.verbose)
       init_class_variables
       init_workspace
-      @id = @options.common.id
+      init_ids
+      init_project_replacement_map
       print_whiteboard
       # ResultUploader must be initialized before adding project to scope
       # Project uses ResultUploader on close, so ResultUploader must exist
@@ -37,6 +39,24 @@ module AutoHCK
       @result_uploader = ResultUploader.new(@scope, self)
 
       scope << self
+    end
+
+    def init_ids
+      @id = @options.common.id
+
+      @run_id = format('%04d', @id)
+      @id_first = @run_id[0..1]
+      @id_second = @run_id[2..3]
+    end
+
+    def init_project_replacement_map
+      @project_replacement_map = ReplacementMap.new(
+        '@run_id@' => @run_id,
+        '@run_id_first@' => @id_first,
+        '@run_id_second@' => @id_second,
+        '@source@' => Dir.pwd,
+        '@workspace@' => @workspace_path
+      )
     end
 
     def print_whiteboard

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -40,6 +40,17 @@ module AutoHCK
       { addr: client.winrm_addr }
     end
 
+    def insert_driver_replacement(driver, replacement)
+      client_replacement = replacement.transform_keys { |k| k.dup.insert(1, "#{driver.short}.") }
+      @replacement_map.merge!(client_replacement)
+
+      # If there is only one driver, we can use generic keys without driver short name.
+      return unless @project.engine.drivers.one?
+
+      @replacement_map.merge!({ '@driver_short_name@' => driver.short })
+      @replacement_map.merge!(replacement)
+    end
+
     def install_drivers
       driver_path = @project.options.test.driver_path
       drivers = @project.engine.drivers
@@ -49,7 +60,10 @@ module AutoHCK
       return if drivers.empty?
 
       @logger.info('Installing drivers on client VM...')
-      drivers.each { |driver| install_driver(driver, driver_path) }
+      drivers.each do |driver|
+        driver_replacement = install_driver(driver, driver_path)
+        insert_driver_replacement(driver, driver_replacement) unless driver_replacement.nil?
+      end
     end
 
     def install_driver(driver, driver_path)

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -5,7 +5,7 @@ module AutoHCK
   #
   # Boots the client VM and prepares it for functest runs (no HLK Studio).
   class FunctestClient
-    attr_reader :name, :tools
+    attr_reader :name, :tools, :replacement_map
 
     def initialize(setup_manager, scope, name, run_opts = nil)
       @project = setup_manager.project
@@ -15,6 +15,7 @@ module AutoHCK
       @logger.info("Starting functest client #{name}")
       @runner = setup_manager.run_client(scope, name, run_opts)
       scope << self
+      @replacement_map = @project.project_replacement_map.merge(setup_manager.client_replacement_map(name))
     end
 
     def prepare_machine

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -22,7 +22,7 @@ module AutoHCK
       @runner = setup_manager.run_client(scope, @name, run_opts)
       scope << self
       @setup_manager = setup_manager
-      @replacement_map = ReplacementMap.new
+      @replacement_map = @project.project_replacement_map.merge(setup_manager.client_replacement_map(name))
     end
 
     def pool

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -106,6 +106,10 @@ module AutoHCK
       HCKClient.new(self, scope, studio, name, run_opts)
     end
 
+    def client_replacement_map(_name)
+      ReplacementMap.new({})
+    end
+
     def self.enter(*); end
   end
 end

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -167,9 +167,10 @@ module AutoHCK
     CONFIG_JSON = 'lib/setupmanagers/qemuhck/qemu_machine.json'
     STATES_JSON = 'lib/setupmanagers/qemuhck/states.json'
 
-    def initialize(options)
+    def initialize(project, options)
       define_local_variables
 
+      @project = project
       load_options(options)
       init_config
       init_ports
@@ -207,8 +208,6 @@ module AutoHCK
       @logger = @options['logger'] || MonoLogger.new($stderr)
 
       @id = format('%04d', @options['id'])
-      @id_first = @id[0..1]
-      @id_second = @id[2..3]
       @client_id = format('%02d', @options['client_id'])
       @run_name = "QemuMachine#{@id}_CL#{@client_id}"
 
@@ -398,25 +397,20 @@ module AutoHCK
     end
 
     def full_replacement_map
-      ReplacementMap.new({
-                           '@run_id@' => @id,
-                           '@run_id_first@' => @id_first,
-                           '@run_id_second@' => @id_second,
-                           '@client_id@' => @client_id,
-                           '@source@' => Dir.pwd,
-                           '@workspace@' => @workspace_path,
-                           '@cpu@' => option_config('cpu'),
-                           '@cpu_options@' => option_config('cpu_options'),
-                           '@cpu_count@' => option_config('cpu_count'),
-                           '@vnc_id@' => @vnc_id,
-                           '@vnc_port@' => @vnc_port,
-                           '@qemu_monitor_port@' => @monitor_port
-                         }, config_replacement_map,
-                         machine_replacement_map,
-                         memory_replacement_map,
-                         options_replacement_map,
-                         device_define_variables,
-                         @define_variables)
+      @project.project_replacement_map.merge({
+                                               '@client_id@' => @client_id,
+                                               '@cpu@' => option_config('cpu'),
+                                               '@cpu_options@' => option_config('cpu_options'),
+                                               '@cpu_count@' => option_config('cpu_count'),
+                                               '@vnc_id@' => @vnc_id,
+                                               '@vnc_port@' => @vnc_port,
+                                               '@qemu_monitor_port@' => @monitor_port
+                                             }, config_replacement_map,
+                                             machine_replacement_map,
+                                             memory_replacement_map,
+                                             options_replacement_map,
+                                             device_define_variables,
+                                             @define_variables)
     end
 
     def read_dynamic_device(device)

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -344,6 +344,10 @@ module AutoHCK
       }
     end
 
+    def replacement_map
+      ReplacementMap.new(machine_replacement_map, { '@client_id@' => @client_id })
+    end
+
     def memory_replacement_map
       memory_gb = option_config('memory_gb')
 

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -337,7 +337,7 @@ module AutoHCK
     def machine_replacement_map
       {
         '@bus_name@' => @machine['bus_name'],
-        '@ctrl_bus_name@' => @machine['ctrl_bus_name'],
+        '@ctrl_bus_name@' => @machine['ctrl_dev_bus_name'],
         '@disable_s3_param@' => @machine['disable_s3_param'],
         '@disable_s4_param@' => @machine['disable_s4_param'],
         '@machine_name@' => @machine_name

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -280,6 +280,10 @@ module AutoHCK
       FunctestClient.new(self, scope, name, run_opts)
     end
 
+    def client_replacement_map(name)
+      @clients_vm[name].replacement_map
+    end
+
     def self.enter(workspace_path)
       $stderr.write "[qemuhck.rb] Entering namespace: #{workspace_path}\n" if ENV['AUTOHCK_NS_VERBOSE']
       T.unsafe(Ns).enter workspace_path, Dir.pwd, 'bin/auto_hck', '-w',

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -57,7 +57,7 @@ module AutoHCK
     end
 
     def initialize_studio_vm
-      @studio_vm = QemuMachine.new(studio_vm_options)
+      @studio_vm = QemuMachine.new(@project, studio_vm_options)
     end
 
     def drivers_options
@@ -128,7 +128,7 @@ module AutoHCK
       @platform.clients.each_with_index do |(_k, v), i|
         vm_options = client_vm_options(v, i)
         @logger.debug("Creating client VM #{v.name} with options: #{vm_options}")
-        @clients_vm[v.name] = QemuMachine.new(vm_options)
+        @clients_vm[v.name] = QemuMachine.new(@project, vm_options)
       end
     end
 


### PR DESCRIPTION
```
D, [2026-07-13T12:59:38.159038 #98251] DEBUG -- : Initial variable '@run_id@' = '0002'
D, [2026-07-13T12:59:38.159202 #98251] DEBUG -- : Initial variable '@run_id_first@' = '00'
D, [2026-07-13T12:59:38.159271 #98251] DEBUG -- : Initial variable '@run_id_second@' = '02'
D, [2026-07-13T12:59:38.159336 #98251] DEBUG -- : Initial variable '@source@' = '/home/user/Documents/repos/AutoHCK.git'
D, [2026-07-13T12:59:38.159399 #98251] DEBUG -- : Initial variable '@workspace@' = '/home/user/hck-ci/workspace/functest/Balloon-Win2025x64/2026_07_13_12_58_51'
D, [2026-07-13T12:59:38.159465 #98251] DEBUG -- : Initial variable '@bus_name@' = 'pcie'
D, [2026-07-13T12:59:38.159530 #98251] DEBUG -- : Initial variable '@ctrl_bus_name@' = 'root1'
D, [2026-07-13T12:59:38.159590 #98251] DEBUG -- : Initial variable '@disable_s3_param@' = 'ICH9-LPC.disable_s3'
D, [2026-07-13T12:59:38.159651 #98251] DEBUG -- : Initial variable '@disable_s4_param@' = 'ICH9-LPC.disable_s4'
D, [2026-07-13T12:59:38.159711 #98251] DEBUG -- : Initial variable '@machine_name@' = 'q35'
D, [2026-07-13T12:59:38.159770 #98251] DEBUG -- : Initial variable '@client_id@' = '01'
D, [2026-07-13T12:59:38.159830 #98251] DEBUG -- : Initial variable '@Balloon.driver_dir@' = 'C:\Users\ADMINI~1\AppData\Local\Temp\dc605d44-6805-43a9-a5e2-bdb8463c9a21'
D, [2026-07-13T12:59:38.159891 #98251] DEBUG -- : Initial variable '@Balloon.inf_path@' = 'C:\Users\ADMINI~1\AppData\Local\Temp\dc605d44-6805-43a9-a5e2-bdb8463c9a21\balloon.inf'
D, [2026-07-13T12:59:38.159952 #98251] DEBUG -- : Initial variable '@driver_short_name@' = 'Balloon'
D, [2026-07-13T12:59:38.160016 #98251] DEBUG -- : Initial variable '@driver_dir@' = 'C:\Users\ADMINI~1\AppData\Local\Temp\dc605d44-6805-43a9-a5e2-bdb8463c9a21'
D, [2026-07-13T12:59:38.160080 #98251] DEBUG -- : Initial variable '@inf_path@' = 'C:\Users\ADMINI~1\AppData\Local\Temp\dc605d44-6805-43a9-a5e2-bdb8463c9a21\balloon.inf'
D, [2026-07-13T12:59:38.160491 #98251] DEBUG -- : Setting variable 'driver_path' = '/home/user/Downloads/virtio-win-0.1.285/Balloon/2k25/amd64/'
D, [2026-07-13T12:59:38.160591 #98251] DEBUG -- : Setting variable 'driver_inf' = 'balloon.inf'
D, [2026-07-13T12:59:38.160667 #98251] DEBUG -- : Setting variable 'driver_module' = 'balloon'
D, [2026-07-13T12:59:38.160739 #98251] DEBUG -- : Setting variable 'driver_name' = 'VirtIO Balloon Driver'
I, [2026-07-13T12:59:38.160819 #98251]  INFO -- : Test context: driver_module=balloon, driver_inf=balloon.inf
```