### PR TITLE
Functest: Wait for client online before guest commands

### DIFF
--- a/lib/engines/functest/functest_tools.rb
+++ b/lib/engines/functest/functest_tools.rb
@@ -30,6 +30,13 @@ module AutoHCK
       @logger.info("#{machine} is back after reboot")
     end
 
+    # Block until WinRM is reachable. Driver install steps do this implicitly;
+    # functest runs without -d need an explicit wait before guest steps run.
+    def wait_for_client_online(machine)
+      wait_for_machine_winrm(machine)
+      @logger.info("#{machine} is online")
+    end
+
     private
 
     def wait_for_machine_winrm(machine)

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -21,6 +21,7 @@ module AutoHCK
     def prepare_machine
       @logger.info("Preparing client #{@name}...")
       @tools = FunctestTools.new(@project, @name, client_winrm_addr)
+      @tools.wait_for_client_online(@name)
       @project.extra_sw_manager.install_software_before_driver(@tools, @name)
       install_drivers
       @project.extra_sw_manager.install_software_after_driver(@tools, @name)


### PR DESCRIPTION
**Issue:**
 `FunctestClient.install_drivers` returned early when the drivers list was empty, skipping the WinRM readiness wait. Any subsequent `guest_run` step would then fail because the VM was not yet reachable.
This surfaces in installer functional tests where the driver is configured with `install_method: "no-drv"`. The driver list is effectively empty after filtering, so the wait was skipped entirely.

**Fix:**
Move the `wait_for_client_online` call before the empty-drivers guard so functest runs without `-d` (or with no-drv drivers) still wait for the guest before executing test steps.
