### PR TITLE
Add --test-param CLI option for runtime parameters

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -116,6 +116,7 @@ module AutoHCK
     prop :discard_granularity, T.nilable(String)
     prop :fs_daemon_cache_mode, T.nilable(String)
     prop :pcie_spare_root_ports, T.nilable(Integer)
+    prop :test_params, T::Hash[String, String], default: {}
 
     def aio_native=(value)
       raise(AutoHCKError, '--aio-native cannot be combined with --aio-threads') if value && drive_aio_state == 'threads'
@@ -324,6 +325,13 @@ module AutoHCK
                 'Allocate N extra empty pcie-root-ports at boot for later hotplug (q35 only, default: 0)',
                 'Max N depends on QEMU',
                 &method(:pcie_spare_root_ports=))
+      parser.on('--test-param KEY=VALUE', String,
+                'Set a test parameter (can be repeated, available as @KEY@ in test JSON)') do |kv|
+        key, value = kv.split('=', 2)
+        raise AutoHCKError, "Invalid --test-param format: #{kv}" if key.to_s.empty? || value.nil?
+
+        self.test_params = test_params.merge(key => value)
+      end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -226,6 +226,10 @@ module AutoHCK
       context.set_variable('test_binaries_path', test_binaries_path) if test_binaries_path
 
       set_driver_context_variables(context, @drivers.first)
+
+      @project.options.test.test_params.each do |key, value|
+        context.set_variable(key, value)
+      end
     end
 
     def set_driver_context_variables(context, drv)


### PR DESCRIPTION
**Problem:**
Functest test cases sometimes need runtime parameters that vary between runs (e.g. a path to an older installer for upgrade testing). There was no way to pass these without hardcoding them in the test JSON.

**Fix:**
Add a `--test-param KEY=VALUE` option to the CLI (repeatable). Each key-value pair is set as a context variable in `setup_test_context`, making it available as `@KEY@`  in test JSON files via the existing replacement map.

**Example:**
Pass an older installer path for upgrade testing:

```
  bin/auto_hck --id 53 functest -p Win2025x64_gui -d virtio-win-installer
    --driver-path /path/to/virtio-win-1.9.58/usr/share/virtio-win
    --test-param old_installer_path=/path/to/virtio-win-1.9.52/usr/share/virtio-win
    --testcase installer/bundle_update

```
In the test JSON, `@old_installer_path@` resolves and is used to upload the old installer:

  ```json
  {
      "desc": "Validate old installer path",
      "host_run": "test -f '@old_installer_path@/installer/virtio-win-guest-tools.exe' || { echo 'ERROR: Old installer not found. Use --test-param
  old_installer_path=/path/to/old/virtio-win'; exit 1; }",
      "timeout": 10
  },
  {
      "local_path": "@old_installer_path@/installer/virtio-win-guest-tools.exe",
      "remote_path": "C:\\AutoHCK\\virtio-win-guest-tools-old.exe",
      "direction": "local-to-remote"
  }

