### PR TITLE
Redesign command execution

### DIFF
--- a/jenkins/test_func_balloon.sh
+++ b/jenkins/test_func_balloon.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -ex
+
+test_name="$(basename "${0}" '.sh')"
+
+cd "${WORKSPACE}"
+
+bin/auto_hck --verbose functest \
+    --platform Win2025x64 \
+    --drivers Balloon \
+    --driver-path "${VIRTIO_WIN_PATH}/amd64/2k25/" \
+    --category balloon_driver_tests \
+    --gthb_context_prefix "${test_name}: " \
+    --commit "${GITHUB_COMMIT}"
+
+cat "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"
+# Check that HLK package contains the expected test results
+grep -e '"passed": 3,' "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"

--- a/lib/all.rb
+++ b/lib/all.rb
@@ -34,6 +34,7 @@ module AutoHCK
   autoload_relative :ConfigManager, 'engines/config_manager/config_manager'
   autoload_relative :CmdRun, 'auxiliary/cmd_run'
   autoload_relative :CmdRunError, 'exceptions'
+  autoload_relative :CommandExecutionManager, 'auxiliary/command_execution_manager'
   autoload_relative :DiffChecker, 'auxiliary/diff_checker'
   autoload_relative :Downloader, 'auxiliary/downloader'
   autoload_relative :Engine, 'engines/engine'

--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -1,0 +1,323 @@
+# typed: true
+# frozen_string_literal: true
+
+module AutoHCK
+  # Executes Models::CommandInfo guest, host, file, reboot, QMP, and barrier
+  # actions against one or more machines via Tools / FunctestTools.
+  class CommandExecutionManager
+    extend T::Sig
+    include Helper
+
+    SLEEP_AFTER_REBOOT = 60
+    DEFAULT_FILE_ACTION_REMOTE_PATH = 'C:\\'
+    DEFAULT_FILE_ACTION_LOCAL_PATH = '@workspace@'
+    DEFAULT_TIMEOUT = 300
+
+    RebootStrategy = T.let({
+      FixedSleep: :fixed_sleep,
+      WinrmPoll: :winrm_poll
+    }.freeze, T::Hash[Symbol, Symbol])
+
+    INIT_OPTS_DEFAULTS = T.let({
+      reboot_strategy: RebootStrategy[:FixedSleep],
+      reboot_callback: nil,
+      default_timeout: DEFAULT_TIMEOUT
+    }.freeze, T::Hash[Symbol, T.untyped])
+
+    STEP_TYPE_FIELDS = T.let(%i[
+      guest_run guest_run_file guest_reboot files_action host_run host_run_file
+      barrier qmp_command qmp_wait_event
+    ].freeze, T::Array[Symbol])
+
+    sig { params(init_opts: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+    def validate_init_opts(init_opts)
+      extra_keys = init_opts.keys - INIT_OPTS_DEFAULTS.keys
+      unless extra_keys.empty?
+        raise AutoHCKError.new('initialize'),
+              "Undefined initialization options: #{extra_keys.join(', ')}."
+      end
+
+      INIT_OPTS_DEFAULTS.merge(init_opts)
+    end
+
+    sig do
+      params(
+        project: Project,
+        tools: Tools,
+        machines: T::Array[String],
+        init_opts: T::Hash[Symbol, T.untyped]
+      ).void
+    end
+    def initialize(project:, tools:, machines:, init_opts: {})
+      init_opts = validate_init_opts(init_opts)
+
+      @project = project
+      @tools = tools
+      @logger = project.logger
+      @machines = machines
+      @file_action_handler = FileActionHandler.new(@tools, @logger)
+
+      @reboot_strategy = init_opts[:reboot_strategy]
+      @reboot_callback = init_opts[:reboot_callback]
+      @default_timeout = init_opts[:default_timeout]
+    end
+
+    sig do
+      params(
+        command_info: Models::CommandInfo,
+        replacement: ReplacementMap
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def execute(command_info, replacement: ReplacementMap.new)
+      desc = command_desc(command_info)
+      result = T.let({ desc: desc }, T::Hash[Symbol, T.untyped])
+
+      result[:guest_outputs] = execute_guest(command_info, replacement, desc) if guest_command?(command_info)
+      execute_guest_reboot(desc) if command_info.guest_reboot
+      execute_host(command_info, replacement, desc) if host_command?(command_info)
+      execute_files_actions(command_info, replacement) unless command_info.files_action.empty?
+      execute_barrier(command_info) if command_info.barrier
+      result[:qmp_result] = execute_qmp_command(command_info) if command_info.qmp_command
+      result[:qmp_event] = execute_qmp_wait_event(command_info) if command_info.qmp_wait_event
+
+      result
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+
+    sig { params(machine_name: String).returns(ReplacementMap) }
+    def machine_replacement_map(machine_name)
+      @project.project_replacement_map.merge(@project.setup_manager.client_replacement_map(machine_name))
+    end
+
+    private
+
+    sig { params(command_info: Models::CommandInfo).returns(String) }
+    def command_desc(command_info)
+      command_info.desc
+    end
+
+    sig { params(command_info: Models::CommandInfo).returns(T::Boolean) }
+    def guest_command?(command_info)
+      !!(command_info.guest_run || command_info.guest_run_file)
+    end
+
+    sig { params(command_info: Models::CommandInfo).returns(T::Boolean) }
+    def host_command?(command_info)
+      !!(command_info.host_run || command_info.host_run_file)
+    end
+
+    sig do
+      params(
+        command_info: Models::CommandInfo,
+        replacement: ReplacementMap,
+        desc: String
+      ).returns(T::Hash[String, T.untyped])
+    end
+    def execute_guest(command_info, replacement, desc)
+      outputs = {}
+
+      @machines.each do |machine_name|
+        @logger.info("Running command (#{desc}) on client #{machine_name}")
+        command = resolve_guest_command(command_info, machine_name, replacement)
+        @logger.debug("Running command after replacement (#{desc}) on client #{machine_name}: #{command}")
+
+        outputs[machine_name] = @tools.run_on_machine(machine_name, desc, command)
+      end
+
+      outputs
+    end
+
+    sig { params(desc: String).void }
+    def execute_guest_reboot(desc)
+      @machines.each do |machine_name|
+        reboot_machine(machine_name, desc)
+      end
+    end
+
+    sig do
+      params(
+        command_info: Models::CommandInfo,
+        replacement: ReplacementMap,
+        desc: String
+      ).void
+    end
+    def execute_host(command_info, replacement, desc)
+      command = resolve_host_command(command_info, replacement)
+      @logger.info("Running command (#{desc}) on host")
+      @logger.debug("Host command: #{command}")
+      run_cmd(command)
+    end
+
+    sig { params(command_info: Models::CommandInfo, replacement: ReplacementMap).void }
+    def execute_files_actions(command_info, replacement)
+      command_info.files_action.each do |files_action|
+        if files_action.remote_path.nil? && files_action.local_path.nil?
+          @logger.warn('Both remote and local paths are nil, skipping file action')
+          next
+        end
+
+        @machines.each do |machine_name|
+          action = prepare_file_action(files_action, machine_name, replacement, command_info)
+          @file_action_handler.handle(machine_name, action)
+        end
+      end
+    end
+
+    sig do
+      params(
+        files_action: Models::FileActionConfig,
+        machine_name: String,
+        replacement: ReplacementMap,
+        command_info: Models::CommandInfo
+      ).returns(Models::FileActionConfig)
+    end
+    def prepare_file_action(files_action, machine_name, replacement, command_info)
+      map = replacement_map_for(machine_name, replacement, command_info)
+            .merge({ '@client_name@' => machine_name })
+      files_action.dup_and_replace_path(map, DEFAULT_FILE_ACTION_REMOTE_PATH,
+                                        DEFAULT_FILE_ACTION_LOCAL_PATH)
+    end
+
+    sig { params(command_info: Models::CommandInfo).void }
+    def execute_barrier(command_info)
+      @logger.info("Barrier: #{command_info.barrier} (single-VM mode, no-op)")
+    end
+
+    def run_qmp_command(execute, arguments, machine_name)
+      @logger.debug("QMP command: #{execute} on #{machine_name} (args: #{arguments.inspect})")
+      result = @project.setup_manager.run_hypervisor_client_command(machine_name, execute, arguments)
+      @logger.debug("QMP result: #{result.inspect}")
+      result
+    end
+
+    sig { params(command_info: Models::CommandInfo).returns(T.untyped) }
+    def execute_qmp_command(command_info)
+      qmp = T.must(command_info.qmp_command)
+      execute = qmp.execute
+
+      outputs = {}
+      @machines.each do |machine_name|
+        outputs[machine_name] = run_qmp_command(execute, qmp.arguments, machine_name)
+      rescue QMPError => e
+        raise EngineError, "QMP command '#{execute}' failed on #{machine_name}: #{e.message}"
+      end
+
+      outputs
+    end
+
+    sig { params(event: String, machine_name: String, timeout: Integer).returns(T.untyped) }
+    def run_qmp_wait_event(event, machine_name, timeout)
+      @logger.info("Waiting for QMP event '#{event}' on #{machine_name} (timeout: #{timeout}s)")
+      response = @project.setup_manager.wait_for_hypervisor_client_event(machine_name, event, timeout: timeout)
+      @logger.debug("QMP event received: #{response.inspect}")
+
+      response
+    end
+
+    sig { params(command_info: Models::CommandInfo).returns(T.untyped) }
+    def execute_qmp_wait_event(command_info)
+      qmp = T.must(command_info.qmp_wait_event)
+      timeout = qmp.timeout || command_info.timeout || @default_timeout
+      event = qmp.event
+
+      outputs = {}
+      @machines.each do |machine_name|
+        outputs[machine_name] = run_qmp_wait_event(event, machine_name, timeout)
+      rescue QMPError => e
+        raise EngineError, "QMP event '#{event}' wait failed on #{machine_name}: #{e.message}"
+      end
+
+      outputs
+    end
+
+    sig do
+      params(
+        command_info: Models::CommandInfo,
+        machine_name: String,
+        replacement: ReplacementMap
+      ).returns(String)
+    end
+    def resolve_guest_command(command_info, machine_name, replacement)
+      command = if command_info.guest_run_file
+                  read_script_file(T.must(command_info.guest_run_file))
+                else
+                  T.must(command_info.guest_run)
+                end
+
+      replacement_map_for(machine_name, replacement, command_info).replace(command)
+    end
+
+    sig { params(command_info: Models::CommandInfo, replacement: ReplacementMap).returns(String) }
+    def resolve_host_command(command_info, replacement)
+      command = if command_info.host_run_file
+                  read_script_file(T.must(command_info.host_run_file))
+                else
+                  T.must(command_info.host_run)
+                end
+
+      apply_variables(replacement, command_info.variables).create_cmd(command)
+    end
+
+    sig do
+      params(
+        machine_name: String,
+        replacement: ReplacementMap,
+        command_info: Models::CommandInfo
+      ).returns(ReplacementMap)
+    end
+    def replacement_map_for(machine_name, replacement, command_info)
+      apply_variables(
+        machine_replacement_map(machine_name).merge(replacement),
+        command_info.variables
+      )
+    end
+
+    sig do
+      params(
+        map: ReplacementMap,
+        variables: T::Hash[String, String]
+      ).returns(ReplacementMap)
+    end
+    def apply_variables(map, variables)
+      return map if variables.empty?
+
+      extra = variables.each_with_object({}) do |(placeholder, var_name), hash|
+        value = map["@#{var_name}@"]
+        @logger.warn("Variable '#{var_name}' not found for placeholder '#{placeholder}'") if value.nil?
+        hash[placeholder] = value unless value.nil?
+      end
+
+      map.merge(extra)
+    end
+
+    sig { params(path: String).returns(String) }
+    def read_script_file(path)
+      full_path = File.expand_path(path)
+      raise EngineError, "Script file not found: #{full_path}" unless File.exist?(full_path)
+
+      @logger.debug("Loading script from: #{full_path}")
+      File.read(full_path)
+    end
+
+    sig { params(machine_name: String, desc: String).void }
+    def reboot_machine(machine_name, desc)
+      if @reboot_callback
+        @logger.info("Rebooting client #{machine_name} after command (#{desc})")
+        @reboot_callback.call(machine_name)
+        return
+      end
+
+      case @reboot_strategy
+      when RebootStrategy[:WinrmPoll]
+        @logger.info("Rebooting client #{machine_name} after command (#{desc})")
+        @tools.restart_machine_and_wait(machine_name)
+      else
+        @logger.info("Rebooting client #{machine_name} after command (#{desc}) " \
+                     "and sleeping for #{SLEEP_AFTER_REBOOT} seconds")
+        @tools.restart_machine(machine_name)
+        sleep SLEEP_AFTER_REBOOT
+      end
+    end
+  end
+end

--- a/lib/engines/functest/step_handler.rb
+++ b/lib/engines/functest/step_handler.rb
@@ -2,33 +2,18 @@
 
 module AutoHCK
   module Functest
-    # Executes individual JSON test steps against a single client VM.
-    #
-    # Supported step types: guest_run, guest_run_file, files_action,
-    # guest_reboot, host_run, host_run_file, barrier, qmp_command, qmp_wait_event.
+    # Executes functest JSON steps: timeout, error policy, and output validation
+    # wrap CommandExecutionManager#execute.
     class StepHandler
-      include Helper
+      STEP_TYPE_FIELDS = CommandExecutionManager::STEP_TYPE_FIELDS
 
-      STEP_HANDLERS = {
-        'guest_run_file' => :handle_guest_run_file,
-        'guest_run' => :handle_guest_run,
-        'files_action' => :handle_files_action,
-        'guest_reboot' => :handle_guest_reboot,
-        'host_run_file' => :handle_host_run_file,
-        'host_run' => :handle_host_run,
-        'barrier' => :handle_barrier,
-        'qmp_command' => :handle_qmp_command,
-        'qmp_wait_event' => :handle_qmp_wait_event
-      }.freeze
-
-      def initialize(project, tools, machine_name, context, default_timeout:)
+      def initialize(project, command_execution_manager, machine_name, context, default_timeout:)
         @project = project
-        @tools = tools
+        @command_execution_manager = command_execution_manager
         @machine_name = machine_name
         @context = context
         @logger = project.logger
         @default_timeout = default_timeout
-        @file_action_handler = FileActionHandler.new(@tools, @logger)
       end
 
       def execute_step(step, step_index)
@@ -38,7 +23,9 @@ module AutoHCK
         timeout = step.timeout || @default_timeout
 
         Timeout.timeout(timeout) do
-          execute_step_action(step, desc)
+          validate_step_type!(step, desc)
+          result = @command_execution_manager.execute(step, replacement: step_replacement(step))
+          handle_step_result(result, step)
         end
       rescue Timeout::Error
         handle_step_error(step, "Timeout after #{timeout}s: #{desc}")
@@ -49,114 +36,58 @@ module AutoHCK
 
       private
 
-      def execute_step_action(step, desc)
-        types = STEP_HANDLERS.keys.select { |k| step.public_send(k.to_sym) }
+      def validate_step_type!(step, desc)
+        types = STEP_TYPE_FIELDS.select { |field| step_type_set?(step, field) }
         raise EngineError, "No step type set in: #{desc}" if types.empty?
         raise EngineError, "Multiple step types set (#{types.join(', ')}) in: #{desc}" if types.length > 1
-
-        send(STEP_HANDLERS.fetch(types.first), step, desc)
       end
 
-      def handle_guest_run_file(step, desc)
-        run_guest_command(step, read_script_file(step.guest_run_file), desc)
+      def step_type_set?(step, field)
+        value = step.public_send(field)
+        case field
+        when :files_action then value.any?
+        when :guest_reboot then value == true
+        when :guest_run, :guest_run_file, :host_run, :host_run_file, :barrier
+          value.is_a?(String) ? !value.empty? : !value.nil?
+        else
+          !value.nil?
+        end
       end
 
-      def handle_guest_run(step, desc = nil)
-        run_guest_command(step, step.guest_run, desc)
+      def step_replacement(step)
+        return @context.replacement_map if step.variables.empty?
+
+        extra = step.variables.each_with_object({}) do |(placeholder, var_name), hash|
+          value = @context.substitute_variables("@#{var_name}@")
+          hash[placeholder] = value unless value.empty?
+        end
+
+        @context.replacement_map.merge(extra)
       end
 
-      def run_guest_command(step, command, desc = nil)
-        desc ||= command[0..60]
-        command = @context.substitute_variables(command, step.variables)
-
-        output = @tools.run_on_machine(@machine_name, desc, command).to_s
+      def handle_step_result(result, step)
+        output = guest_output(result)
         @logger.debug("Guest output:\n#{output}") unless output.strip.empty?
 
         if step.capture_output
-          @context.set_variable(step.capture_output, output.strip)
-          @logger.debug("Captured '#{step.capture_output}': #{output[0..100]}")
+          captured = capture_value(result, output)
+          @context.set_variable(step.capture_output, captured)
+          @logger.debug("Captured '#{step.capture_output}': #{captured.to_s[0..100]}")
         end
 
         validate_output(output, step)
-
-        { stdout: output }
       end
 
-      def handle_files_action(step, _desc = nil)
-        step.files_action.each { |file_op| run_file_op(file_op) }
+      def guest_output(result)
+        result.fetch(:guest_outputs, {}).fetch(@machine_name, '').to_s
       end
 
-      def run_file_op(file_op)
-        raise EngineError, 'files_action is missing local_path'  if file_op.local_path.nil?
-        raise EngineError, 'files_action is missing remote_path' if file_op.remote_path.nil?
+      def capture_value(result, guest_output)
+        return guest_output.strip unless guest_output.strip.empty?
+        return result[:qmp_result].to_json if result[:qmp_result]
+        return result[:qmp_event].to_json if result[:qmp_event]
 
-        substituted = Models::FileActionConfig.new(
-          local_path: @context.substitute_variables(file_op.local_path),
-          remote_path: @context.substitute_variables(file_op.remote_path),
-          direction: file_op.direction,
-          move: file_op.move,
-          allow_missing: file_op.allow_missing
-        )
-        @file_action_handler.handle(@machine_name, substituted)
-      end
-
-      def handle_guest_reboot(_step, _desc = nil)
-        @tools.restart_machine_and_wait(@machine_name)
-      end
-
-      def handle_host_run(step, _desc = nil)
-        run_host_command(step, step.host_run)
-      end
-
-      def handle_host_run_file(step, _desc = nil)
-        run_host_command(step, read_script_file(step.host_run_file))
-      end
-
-      def run_host_command(step, command)
-        command = @context.substitute_variables(command, step.variables)
-        @logger.debug("Host command: #{command}")
-        run_cmd(command)
-      end
-
-      def handle_barrier(step, _desc = nil)
-        @logger.info("Barrier: #{step.barrier} (single-VM mode, no-op)")
-      end
-
-      # Send a QMP command to the client VM at the hypervisor level.
-      # The step JSON mirrors the QMP wire format — use "execute" and "arguments"
-      # exactly as you would in a raw QMP session.
-      # Example: { "qmp_command": { "execute": "balloon", "arguments": { "value": 536870912 } } }
-      def handle_qmp_command(step, _desc = nil)
-        qmp    = step.qmp_command
-        result = run_qmp_command(qmp.execute, qmp.arguments)
-        @context.set_variable(step.capture_output, result.to_json) if step.capture_output
-        { result: result }
-      end
-
-      def run_qmp_command(cmd, arguments)
-        @logger.debug("QMP command: #{cmd} on #{@machine_name} (args: #{arguments.inspect})")
-        result = @project.setup_manager.run_hypervisor_client_command(@machine_name, cmd, arguments)
-        @logger.debug("QMP result: #{result.inspect}")
-        result
-      rescue QMPError => e
-        raise "QMP command '#{cmd}' failed on #{@machine_name}: #{e.message}"
-      end
-
-      # Block until a specific QMP event arrives from the client VM.
-      # Step JSON example:
-      #   { "qmp_wait_event": { "event": "BALLOON_CHANGE", "timeout": 30 } }
-      def handle_qmp_wait_event(step, _desc = nil)
-        qmp     = step.qmp_wait_event
-        timeout = qmp.timeout || @default_timeout
-
-        @logger.info("Waiting for QMP event '#{qmp.event}' on #{@machine_name} (timeout: #{timeout}s)")
-        response = @project.setup_manager.wait_for_hypervisor_client_event(@machine_name, qmp.event, timeout: timeout)
-        @logger.debug("QMP event received: #{response.inspect}")
-
-        @context.set_variable(step.capture_output, response.to_json) if step.capture_output
-        { event: response }
-      rescue QMPError => e
-        raise "QMP event '#{qmp.event}' wait failed on #{@machine_name}: #{e.message}"
+        ''
       end
 
       def validate_output(output, step)
@@ -172,16 +103,6 @@ module AutoHCK
 
       def handle_step_error(step, error_message)
         raise error_message unless step.ignore_errors
-      end
-
-      # Reads local script file content, to be run either inline on the host
-      # or sent inline to the guest over WinRM.
-      def read_script_file(path)
-        full_path = File.expand_path(path)
-        raise EngineError, "Script file not found: #{full_path}" unless File.exist?(full_path)
-
-        @logger.debug("Loading script from: #{full_path}")
-        File.read(full_path)
       end
     end
   end

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -3,57 +3,6 @@
 
 module AutoHCK
   module Functest
-    # Config for a qmp_command step
-    class QmpCommandConfig < T::Struct
-      extend T::Sig
-
-      const :execute, String
-      const :arguments, T.nilable(T::Hash[String, T.untyped])
-    end
-
-    # Config for a qmp_wait_event step
-    class QmpWaitEventConfig < T::Struct
-      extend T::Sig
-
-      const :event, String
-      const :timeout, T.nilable(Integer)
-    end
-
-    # A single test step. Exactly one step-type field should be set; the rest must stay nil.
-    #
-    # Fields shared with AutoHCK::Models::CommandInfo (hcktest):
-    #   desc, guest_run, guest_reboot, files_action, host_run
-    #
-    # Functest-only fields (not processed by hcktest):
-    #   timeout, capture_output, ignore_errors, variables,
-    #   guest_run_file, host_run_file, barrier, qmp_command, qmp_wait_event,
-    #   expected_output_contains, expected_output_matches
-    class TestStep < T::Struct
-      extend T::Sig
-
-      # Common fields
-      const :desc, T.nilable(String)
-      const :timeout, T.nilable(Integer)
-      const :capture_output, T.nilable(String)
-      const :ignore_errors, T.nilable(T::Boolean)
-      const :variables, T::Hash[String, String], default: {}
-
-      # Step type fields — exactly one should be non-nil/truthy
-      const :guest_run, T.nilable(String)
-      const :guest_run_file, T.nilable(String)
-      const :guest_reboot, T.nilable(T::Boolean)
-      const :files_action, T.nilable(T::Array[Models::FileActionConfig])
-      const :host_run, T.nilable(String)
-      const :host_run_file, T.nilable(String)
-      const :barrier, T.nilable(String)
-      const :qmp_command, T.nilable(QmpCommandConfig)
-      const :qmp_wait_event, T.nilable(QmpWaitEventConfig)
-
-      # Output validation
-      const :expected_output_contains, T.nilable(String)
-      const :expected_output_matches, T.nilable(String)
-    end
-
     # A single test case loaded from a JSON file
     class TestCase < T::Struct
       extend T::Sig
@@ -63,8 +12,8 @@ module AutoHCK
       const :description, T.nilable(String)
       const :test_system_ref, T.nilable(String)
       const :timeout, T.nilable(Integer)
-      const :test_steps, T::Array[TestStep]
-      const :cleanup, T::Array[TestStep], default: []
+      const :test_steps, T::Array[Models::CommandInfo]
+      const :cleanup, T::Array[Models::CommandInfo], default: []
     end
   end
 end

--- a/lib/engines/functest/test_context.rb
+++ b/lib/engines/functest/test_context.rb
@@ -4,7 +4,7 @@ module AutoHCK
   module Functest
     # TestContext holds runtime state for test execution
     class TestContext
-      attr_reader :logger, :project
+      attr_reader :logger, :project, :replacement_map
 
       def initialize(project, replacement_map)
         @project = project

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -14,11 +14,13 @@ module AutoHCK
 
       def initialize(project, client, default_timeout:)
         @project = project
+        @client = client
         @tools = client.tools
         @machine_name = client.name
         @logger = project.logger
         @context = TestContext.new(project, client.replacement_map)
-        @step_handler = StepHandler.new(project, @tools, @machine_name, @context,
+        @command_execution_manager = client.command_execution_manager
+        @step_handler = StepHandler.new(project, @command_execution_manager, @machine_name, @context,
                                         default_timeout: default_timeout)
         @results = []
       end

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -191,9 +191,17 @@ module AutoHCK
 
     def run_clients_post_start_host_commands
       post_start_commands.each do |command|
-        @logger.info("Running command (#{command.desc}) on host")
-        run_cmd(command.host_run)
+        command_execution_manager.execute(command)
       end
+    end
+
+    def command_execution_manager
+      client, support = @clients.values
+      @command_execution_manager ||= CommandExecutionManager.new(
+        project: @project,
+        tools: @studio.tools,
+        machines: [client.name, support&.name].compact
+      )
     end
 
     def configure_and_synchronize_clients

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -5,7 +5,6 @@
 module AutoHCK
   class HCKTest
     # Tests class
-    # rubocop:disable Metrics/ClassLength
     class Tests
       extend T::Sig
       include Helper
@@ -14,16 +13,12 @@ module AutoHCK
 
       HANDLE_TESTS_POLLING_INTERVAL = 60
       APPLYING_FILTERS_INTERVAL = 50
-      SLEEP_AFTER_REBOOT = 60
       TOOLS_ACTION_RETRIES = 5
       TOOLS_ACTION_SLEEP = 5
       QUEUE_TEST_TIMEOUT = '00:15:00'
       RUNNING_TEST_TIMEOUT = '00:15:00'
       SUMMARY_LOG_FILE = 'logs.txt'
       STUDIO_PACKAGE_ASSETS_PATH = 'C:\\AutoHCK\\PackageAssets'
-
-      DEFAULT_FILE_ACTION_REMOTE_PATH = 'C:\\'
-      DEFAULT_FILE_ACTION_LOCAL_PATH = '@workspace@'
 
       def initialize(client, support, project, target, tools)
         @client = client
@@ -33,11 +28,11 @@ module AutoHCK
         @tools = tools
         @support = support
         @logger = project.logger
-        @file_action_handler = FileActionHandler.new(@tools, @logger)
+        @replacement_map = @project.project_replacement_map
+        @command_execution_manager = project.engine.command_execution_manager
         @playlist = Playlist.new(client, project, target, tools, @client.kit)
         @tests = T.let([], T::Array[Models::HLK::Test])
         @test_results = []
-        @replacement_map = @project.project_replacement_map
       end
 
       sig { params(updated_tests: T::Array[Models::HLK::Test]).returns(T::Array[Models::HLK::Test]) }
@@ -194,78 +189,10 @@ module AutoHCK
         select_test_config(test_name, :errata).compact.first
       end
 
-      def run_command_on_client(client, command, desc, guest_reboot, replacement)
-        cl_name = client.name
-        @logger.info("Running command (#{desc}) on client #{cl_name}")
-        # Don't use create_cmd because it calls shellescape that performs wrong escaping for Windows commands
-        # E.g. it escapes backslashes that are used in Windows paths
-        updated_command = client.replacement_map.merge(@replacement_map).merge(replacement).replace(command)
-        @logger.debug("Running command after replacement (#{desc}) on client #{cl_name}: #{updated_command}")
-
-        @tools.run_on_machine(cl_name, desc, updated_command)
-
-        return unless guest_reboot
-
-        @logger.info("Rebooting client #{cl_name} after command (#{desc}) " \
-                     "and sleeping for #{SLEEP_AFTER_REBOOT} seconds")
-        @tools.restart_machine(cl_name)
-        # Reboot takes some time, so we need to wait until machine is ready otherwise next commands can fail
-        # with strange WinRMAuthorizationError error because Windows prevents connections to the machine during reboot
-        # There is no good way to check if machine is ready, so just wait some time after reboot
-        sleep SLEEP_AFTER_REBOOT
-      end
-
-      def run_guest_test_command(command, replacement)
-        return unless command.guest_run
-
-        run_command_on_client(@client, command.guest_run, command.desc, command.guest_reboot, replacement)
-        return if @support.nil?
-
-        run_command_on_client(@support, command.guest_run, command.desc, command.guest_reboot, replacement)
-      end
-
-      def run_host_test_command(command)
-        return unless command.host_run
-
-        @logger.info("Running command (#{command.desc}) on host")
-        run_cmd(command.host_run)
-      end
-
-      sig do
-        params(client_name: String, files_action: Models::FileActionConfig, replacement: ReplacementMap).void
-      end
-      def prepare_file_action_for_client(client_name, files_action, replacement)
-        client_replacement = replacement.merge({ '@client_name@' => client_name })
-        updated_action = files_action.dup_and_replace_path(client_replacement, DEFAULT_FILE_ACTION_REMOTE_PATH,
-                                                           DEFAULT_FILE_ACTION_LOCAL_PATH)
-        @file_action_handler.handle(client_name, updated_action)
-      end
-
-      sig do
-        params(files_actions: T::Array[Models::FileActionConfig], replacement: ReplacementMap).void
-      end
-      def run_file_actions(files_actions, replacement)
-        files_actions.each do |files_action|
-          if files_action.remote_path.nil? && files_action.local_path.nil?
-            @logger.warn('Both remote and local paths are nil, skipping file action')
-            next
-          end
-
-          prepare_file_action_for_client(@client.name, files_action, replacement)
-
-          next if @support.nil?
-
-          prepare_file_action_for_client(@support.name, files_action, replacement)
-        end
-      end
-
       sig { params(test: Models::HLK::Test, type: Symbol, replacement: ReplacementMap).void }
       def run_test_commands(test, type, replacement)
         select_test_config(test.name, type).each do |command|
-          run_guest_test_command(command, replacement)
-          run_host_test_command(command)
-
-          run_file_actions(command.files_action, replacement)
+          @command_execution_manager.execute(command, replacement: replacement)
         end
       end
 
@@ -731,6 +658,5 @@ module AutoHCK
         retry_tests(tests) unless @project.options.test.auto_retry_failed_tests.zero?
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -258,6 +258,10 @@ module AutoHCK
       retry
     end
 
+    def restart_machine_and_wait(_machine)
+      raise ToolsHCKError, 'Unimplemented method: restart_machine_and_wait'
+    end
+
     def restart_machine(machine)
       retries ||= 0
       act_with_tools { _1.machine_shutdown(machine, restart: true) }

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -43,16 +43,44 @@ module AutoHCK
       end
     end
 
-    # CommandInfo class
+    class QmpCommandConfig < T::Struct
+      extend T::Sig
+
+      const :execute, String
+      const :arguments, T.nilable(T::Hash[String, T.untyped])
+    end
+
+    class QmpWaitEventConfig < T::Struct
+      extend T::Sig
+
+      const :event, String
+      const :timeout, T.nilable(Integer)
+    end
+
+    # Unified command/step descriptor for HCK test hooks, post-start commands,
+    # and functest JSON steps.
     class CommandInfo < T::Struct
       extend T::Sig
       extend JsonHelper
 
       const :desc, String
-      const :host_run, T.nilable(String)
+      const :timeout, T.nilable(Integer)
+      const :capture_output, T.nilable(String)
+      const :ignore_errors, T.nilable(T::Boolean)
+      const :variables, T::Hash[String, String], default: {}
+
       const :guest_run, T.nilable(String)
+      const :guest_run_file, T.nilable(String)
       const :guest_reboot, T::Boolean, default: false
       const :files_action, T::Array[FileActionConfig], default: []
+      const :host_run, T.nilable(String)
+      const :host_run_file, T.nilable(String)
+      const :barrier, T.nilable(String)
+      const :qmp_command, T.nilable(QmpCommandConfig)
+      const :qmp_wait_event, T.nilable(QmpWaitEventConfig)
+
+      const :expected_output_contains, T.nilable(String)
+      const :expected_output_matches, T.nilable(String)
     end
   end
 end

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -26,6 +26,19 @@ module AutoHCK
       @project.extra_sw_manager.install_software_after_driver(@tools, @name)
     end
 
+    def command_execution_manager
+      raise AutoHCKError, 'Tools not initialized; call prepare_machine first' unless @tools
+
+      @command_execution_manager ||= CommandExecutionManager.new(
+        project: @project,
+        tools: @tools,
+        machines: [@name],
+        init_opts: {
+          reboot_strategy: CommandExecutionManager::RebootStrategy[:WinrmPoll]
+        }
+      )
+    end
+
     def close
       @logger.info("Exiting FunctestClient #{@name}")
     end

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -86,19 +86,19 @@ module AutoHCK
 
     def run_post_start_commands
       post_start_commands&.each do |command|
-        desc = command.desc
-        @logger.info("Running command (#{desc}) on client #{@name}")
-        updated_command = @replacement_map.create_cmd(command.guest_run)
-        @logger.debug("Running command after replacement (#{desc}) on client #{@name}: #{updated_command}")
-
-        @tools.run_on_machine(@name, desc, updated_command)
-        next unless command.guest_reboot
-
-        @logger.info("Rebooting client #{@name} after command (#{desc})")
-        # Reconfigure machine calls reboot, so no need to call reboot separately here.
-        # No extra wait needed, reconfigure_machine waits until machine is ready in HCK Controller.
-        reconfigure_machine
+        command_execution_manager.execute(command)
       end
+    end
+
+    def command_execution_manager
+      @command_execution_manager ||= CommandExecutionManager.new(
+        project: @project,
+        tools: @tools,
+        machines: [@name],
+        init_opts: {
+          reboot_callback: ->(_name) { reconfigure_machine }
+        }
+      )
     end
 
     def install_driver(driver)

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -273,14 +273,19 @@ module AutoHCK
     end
 
     def run_hck_client(scope, studio, name, run_opts)
-      HCKClient.new(self, scope, studio, name, run_opts)
+      @clients ||= {}
+      @clients[name] = HCKClient.new(self, scope, studio, name, run_opts)
     end
 
     def run_functest_client(scope, name, run_opts = nil)
-      FunctestClient.new(self, scope, name, run_opts)
+      @clients ||= {}
+      @clients[name] = FunctestClient.new(self, scope, name, run_opts)
     end
 
     def client_replacement_map(name)
+      client = @clients&.[](name)
+      return client.replacement_map if client
+
       @clients_vm[name].replacement_map
     end
 


### PR DESCRIPTION
Generalize all command execution and move to one manager. Engines now use command execution manager instead of manual processing each command type.