### PR TITLE
Functest: Support device-only tests via --test-binaries-path

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -14,7 +14,8 @@ The functest engine runs JSON-driven functional tests against a Windows client V
 |---|---|
 | `-p`, `--platform <name>` | Platform name (maps to `lib/engines/hcktest/platforms/<name>.json`) |
 | `-d`, `--drivers <list>` | Comma-separated driver short names (maps to `lib/engines/hcktest/drivers/<name>.json`) |
-| `--driver-path <path>` | Host path to the driver package directory; required when drivers are configured |
+| `--driver-path <path>` | Host path to the driver package directory; required when drivers are configured, unless `--test-binaries-path` is used instead (see [Device-only testing](#device-only-testing) below) |
+| `--test-binaries-path <path>` | Host path to binaries the test needs (e.g. an installer); available to test steps as `@test_binaries_path@` |
 | `--category <suite>` | Run a named test suite; `<suite>` is the suite name from `lib/engines/functest/tests/suites/<suite>.json` |
 | `--testcase <names>` | Comma-separated list of test case names to run (e.g. `driver_sign_check,balloon/balloon_service`) |
 | `--select-test-names <file>` | Path to a text file (one test name per line); only tests whose name appears in the file are kept |
@@ -80,6 +81,27 @@ Where each file contains one test name per line, e.g.:
 balloon/balloon_service
 driver_update
 ```
+
+### Device-only testing
+
+Pass `--test-binaries-path <path>` without `--driver-path` to attach configured devices (`-d`) while skipping
+driver installation. The content of `--test-binaries-path` is uploaded to the client VM automatically (to
+`C:\AutoHCK\test_binaries`). The host path is exposed to test steps as `@test_binaries_path@`, and the
+uploaded guest path as `@test_binaries_dir@`.
+
+```bash
+./bin/auto_hck functest \
+  -p Win2025x64_gui \
+  -d Balloon \
+  --test-binaries-path /path/to/installer \
+  --testcase <test-name>
+```
+
+| `--driver-path` | `--test-binaries-path` | Result |
+|---|---|---|
+| set | any | Normal driver installation |
+| nil | set | Driver installation skipped; devices still attached |
+| nil | nil | Error: `--driver-path is required when drivers are configured` |
 
 ## Directory Layout
 
@@ -343,9 +365,11 @@ These are populated automatically from CLI arguments and driver configuration:
 | Variable | Description |
 |---|---|
 | `@driver_path@` | Local path to the driver package directory (`--driver-path` CLI option) |
-| `@driver_module@` | Driver module name derived from the INF filename (e.g. `balloon` from `balloon.inf`) |
-| `@driver_inf@` | INF filename of the driver (e.g. `balloon.inf`) |
+| `@driver_module@` | Driver module name derived from the INF filename (e.g. `balloon` from `balloon.inf`). Not set for `no-drv` drivers, which have no INF. |
+| `@driver_inf@` | INF filename of the driver (e.g. `balloon.inf`). Not set for `no-drv` drivers, which have no INF. |
 | `@driver_name@` | Full driver name as defined in the driver JSON configuration |
+| `@test_binaries_path@` | Local host path to test binaries content (`--test-binaries-path` CLI option); see [Device-only testing](#device-only-testing) |
+| `@test_binaries_dir@` | Guest path where `--test-binaries-path` content was uploaded (`C:\AutoHCK\test_binaries`) |
 
 ### Step-level Variable Overrides
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -83,6 +83,7 @@ module AutoHCK
     prop :platform, T.nilable(String)
     prop :drivers, T::Array[String], default: []
     prop :driver_path, T.nilable(String)
+    prop :test_binaries_path, T.nilable(String)
     prop :supplemental_path, T.nilable(String)
     prop :package_with_driver, Symbol, default: :none
     prop :commit, T.nilable(String)
@@ -151,6 +152,13 @@ module AutoHCK
       parser.on('--driver-path <driver_path>', String,
                 'Path to the location of the driver wanted to be tested',
                 &method(:driver_path=))
+
+      parser.on('--test-binaries-path <test_binaries_path>', String,
+                'Path to arbitrary binaries/content needed by the test (e.g. a third-party installer);',
+                'available to test steps as @test_binaries_path@ (used with functest engine).',
+                'When set without --driver-path, driver installation is skipped and configured',
+                'devices are attached without installing their driver package.',
+                &method(:test_binaries_path=))
 
       parser.on('--supplemental-path <supplemental_path>', String,
                 'Path to the supplemental content folder (e.g. for README)',

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -208,16 +208,25 @@ module AutoHCK
       driver_path = @project.options.test.driver_path
       context.set_variable('driver_path', driver_path) if driver_path
 
+      test_binaries_path = @project.options.test.test_binaries_path
+      context.set_variable('test_binaries_path', test_binaries_path) if test_binaries_path
+
       set_driver_context_variables(context, @drivers.first)
     end
 
     def set_driver_context_variables(context, drv)
       return unless drv
 
+      context.set_variable('driver_name', drv.name)
+
+      unless drv.inf
+        @logger.info("Driver #{drv.name} has no package (device-only); skipping driver_inf/driver_module")
+        return
+      end
+
       module_name = drv.inf.sub(/\.inf$/i, '')
       context.set_variable('driver_inf', drv.inf)
       context.set_variable('driver_module', module_name)
-      context.set_variable('driver_name', drv.name)
 
       @logger.info("Test context: driver_module=#{module_name}, driver_inf=#{drv.inf}")
     end

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -5,6 +5,8 @@ module AutoHCK
   #
   # Boots the client VM and prepares it for functest runs (no HLK Studio).
   class FunctestClient
+    TEST_BINARIES_REMOTE_PATH = 'C:\\AutoHCK\\test_binaries'
+
     attr_reader :name, :tools, :replacement_map
 
     def initialize(setup_manager, scope, name, run_opts = nil)
@@ -23,6 +25,7 @@ module AutoHCK
       @tools = FunctestTools.new(@project, @name, client_winrm_addr)
       @project.extra_sw_manager.install_software_before_driver(@tools, @name)
       install_drivers
+      copy_test_binaries
       @project.extra_sw_manager.install_software_after_driver(@tools, @name)
     end
 
@@ -64,19 +67,37 @@ module AutoHCK
       @replacement_map.merge!(replacement)
     end
 
+    def copy_test_binaries
+      test_binaries_path = @project.options.test.test_binaries_path
+      return unless test_binaries_path
+
+      @logger.info("Copying test binaries to client #{@name}...")
+      remote_path = @tools.upload_to_machine(@name, test_binaries_path, TEST_BINARIES_REMOTE_PATH)
+      @replacement_map.merge!({ '@test_binaries_dir@' => remote_path })
+    end
+
     def install_drivers
       driver_path = @project.options.test.driver_path
       drivers = @project.engine.drivers
-      raise AutoHCKError, '--driver-path is required when drivers are configured' \
-        if drivers.any? && driver_path.nil?
 
       return if drivers.empty?
+      return if skip_drivers_installation?(driver_path)
+
+      raise AutoHCKError, '--driver-path is required when drivers are configured' if driver_path.nil?
 
       @logger.info('Installing drivers on client VM...')
       drivers.each do |driver|
         driver_replacement = install_driver(driver, driver_path)
         insert_driver_replacement(driver, driver_replacement) unless driver_replacement.nil?
       end
+    end
+
+    def skip_drivers_installation?(driver_path)
+      return false unless driver_path.nil? && @project.options.test.test_binaries_path
+
+      @logger.info('--test-binaries-path provided without --driver-path: ' \
+                   'skipping driver installation, device(s) attached only')
+      true
     end
 
     def install_driver(driver, driver_path)


### PR DESCRIPTION
Some tests need to attach a device without installing its driver.
Passing --test-binaries-path without --driver-path skips driver
installation but still attaches the device.
The content is copied to the guest automatically, and
available to test steps as @test_binaries_path@ (host path) and
@test_binaries_dir@ (guest path).