### PR TITLE
VIRTWINKVM-1882: Read VM names from config

### DIFF
--- a/lib/engines/hckinstall/hckinstall.rb
+++ b/lib/engines/hckinstall/hckinstall.rb
@@ -316,7 +316,8 @@ module AutoHCK
         kit_type:,
         hlk_kit_ver: kit_version,
         debug: options_install.debug,
-        no_reboot_after_bugcheck: options_install.no_reboot_after_bugcheck
+        no_reboot_after_bugcheck: options_install.no_reboot_after_bugcheck,
+        vmnames: ['STUDIO'] + @clients_name.map(&:upcase)
       }
 
       prepare_kit_installer(kit_type, kit_version)

--- a/lib/engines/hckinstall/setup-scripts/args.ps1.example
+++ b/lib/engines/hckinstall/setup-scripts/args.ps1.example
@@ -1,3 +1,4 @@
+$VMNAMES = @('STUDIO', 'CL1', 'CL2')
 $KITTYPE = "HLK"
 $HLKKITVER = 2004
 $REMOVEGUI = $false

--- a/lib/engines/hckinstall/setup-scripts/auxiliary.ps1
+++ b/lib/engines/hckinstall/setup-scripts/auxiliary.ps1
@@ -1,6 +1,5 @@
 $FILTERS = "https://go.microsoft.com/fwlink/?linkid=875139"
-$STUDIOCOMPUTERNAME = "STUDIO"
-$CLIENTCOMPUTERNAME = "CL"
+$VMNAMES = @('STUDIO', 'CL1', 'CL2')
 $CONTROLNET = "192.168.100" # The =FIRST THREE= octets of the IP
 $STUDIOIP = "${CONTROLNET}.1"
 $KITTYPE = "HLK"

--- a/lib/engines/hckinstall/setup-scripts/client.ps1
+++ b/lib/engines/hckinstall/setup-scripts/client.ps1
@@ -34,7 +34,10 @@ function Stage-One {
         if (($macSegments[5] -eq "CC") -and ($macSegments[4] -eq "CC")) {
             $clientNumber = [int32]("0x" + $macSegments[3])
             $clientIp = $clientNumber + 1
-            $clientName = "$CLIENTCOMPUTERNAME$clientNumber"
+            $clientName = $VMNAMES[$clientNumber]
+            if (-not $clientName) {
+                Write-Error "No VM name found in VMNAMES for client number $clientNumber"
+            }
 
             Write-Output "Renaming hostname to $clientName"
             Rename-Computer -NewName "$clientName"
@@ -49,7 +52,7 @@ function Stage-One {
         }
     }
 
-    "$STUDIOIP $STUDIOCOMPUTERNAME #STUDIO VM IP" |  Out-File -encoding ASCII -append 'C:\Windows\System32\drivers\etc\hosts'
+    "$STUDIOIP $($VMNAMES[0]) #STUDIO VM IP" |  Out-File -encoding ASCII -append 'C:\Windows\System32\drivers\etc\hosts'
 
     Enable-PowerShellRemoting
 
@@ -73,17 +76,17 @@ function Stage-Three {
     Set-NewStage -Stage "Four"
 
     do {
-        Write-Output "Waiting for ping to $STUDIOCOMPUTERNAME..."
+        Write-Output "Waiting for ping to $($VMNAMES[0])..."
         # The correct parameter is -ComputerName for PowerShell v5.1. The parameter changed to -TargetName in PowerShell v6.
         # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7.1
         # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-connection?view=powershell-5.1
-        $pingStatus = Test-Connection -ComputerName "$STUDIOCOMPUTERNAME" -Quiet
+        $pingStatus = Test-Connection -ComputerName "$($VMNAMES[0])" -Quiet
     } until ($pingStatus)
 
     Write-Output "Copying $KITTYPE client installation from studio to client..."
 
     $clientInstallerFolder = "$env:TEMP\Client"
-    Copy-Item -Path "\\$STUDIOCOMPUTERNAME\${KITTYPE}Install\Client" -Destination "$clientInstallerFolder" -Recurse
+    Copy-Item -Path "\\$($VMNAMES[0])\${KITTYPE}Install\Client" -Destination "$clientInstallerFolder" -Recurse
 
     Write-Output "Starting $KITTYPE client installation..."
     # HLK Installer

--- a/lib/engines/hckinstall/setup-scripts/studio.ps1
+++ b/lib/engines/hckinstall/setup-scripts/studio.ps1
@@ -22,7 +22,7 @@ function Stage-One {
     Disable-Screensaver
     Disable-PowerSavingOptions
 
-    Rename-Computer -NewName "$STUDIOCOMPUTERNAME"
+    Rename-Computer -NewName "$($VMNAMES[0])"
 
     Get-NetAdapter | ForEach-Object {
         $adapterName = $_.Name

--- a/lib/engines/hckinstall/setup_scripts_helper.rb
+++ b/lib/engines/hckinstall/setup_scripts_helper.rb
@@ -12,7 +12,8 @@ module AutoHCK
       hlk_kit_ver: '',
       remove_gui: '',
       debug: '',
-      no_reboot_after_bugcheck: ''
+      no_reboot_after_bugcheck: '',
+      vmnames: []
     }.freeze
 
     sig { params(workspace_hlk_setup_scripts_path: Pathname, hck_setup_scripts_template_path: Pathname).void }
@@ -71,6 +72,9 @@ module AutoHCK
             value = "'#{v}'"
           when Integer
             value = v
+          when Array
+            items = v.map { |item| "'#{item.to_s.gsub("'", "''")}'" }.join(', ')
+            value = "@(#{items})"
           else
             @logger.fatal("Unexpected value #{v} for config")
             Kernel.raise(AutoHCKError, "Unexpected value #{v} for config")

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -27,7 +27,7 @@ module AutoHCK
 
     def pool
       @studio.list_pools.each do |pool|
-        return pool['name'] if pool['machines'].any? { |machine| machine['name'].eql?(@name) }
+        return pool['name'] if pool['machines'].any? { |machine| machine['name']&.casecmp?(@name) }
       end
     end
 
@@ -152,8 +152,8 @@ module AutoHCK
     end
 
     def machine_info
-      @studio.list_pools.flat_map { |pool| pool['machines'] }
-                        .detect { |machine| machine['name'].eql?(@name) }
+      machines = @studio.list_pools.flat_map { |pool| pool['machines'] }
+      machines.detect { |machine| machine['name']&.casecmp?(@name) }
     end
 
     def recognize_client_wait


### PR DESCRIPTION
1. Hostnames come from platform JSON — not hardcoded "CL" + number, so custom names  work.
2. One source of truth — Ruby + Windows + HLK use the same client names from the platform.
3. Works with any client count — 1, 2, 3+ clients via args.ps1 ($VMNAMES length matches platform).
4. Lowercase / uppercase JSON both work — install upcases for Windows; test uses casecmp? for HLK.
5. Aligns with Windows/HLK — hostnames are case-insensitive; AutoHCK no longer fails on cl1 vs CL1.
6. Safer for future platforms — change names in JSON + reinstall; no PowerShell formula to update.