### PR TITLE
Extend driver signature verification to cover full package (.sys, .cat, .inf)

### DIFF
--- a/lib/engines/functest/tests/cases/driver_package_check.json
+++ b/lib/engines/functest/tests/cases/driver_package_check.json
@@ -1,0 +1,13 @@
+{
+    "name": "driver_package_check",
+    "description": "Verify Authenticode signatures of the @driver_module@ driver package (.sys, .cat) before installation",
+    "timeout": 60,
+    "test_steps": [
+        {
+            "desc": "Verify Authenticode signatures of @driver_module@ package",
+            "guest_run_file": "lib/engines/functest/tests/scripts/verify_driver_package.ps1",
+            "expected_output_contains": "PASS:",
+            "timeout": 45
+        }
+    ]
+}

--- a/lib/engines/functest/tests/cases/driver_signtool_check.json
+++ b/lib/engines/functest/tests/cases/driver_signtool_check.json
@@ -1,0 +1,19 @@
+{
+    "name": "driver_signtool_check",
+    "description": "Verify @driver_module@ catalog integrity using signtool — requires extra_software signtool",
+    "timeout": 120,
+    "test_steps": [
+        {
+            "desc": "Locate signtool.exe",
+            "guest_run": "$st = Get-Item (Join-Path $env:SystemDrive '\\signtool\\signtool.exe') -ErrorAction SilentlyContinue; if (-not $st) { $st = Get-ChildItem (Join-Path ${env:ProgramFiles(x86)} 'Windows Kits') -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue | Where-Object { $_.Directory.Name -eq 'x64' } | Select-Object -First 1 }; if ($st) { Write-Output $st.FullName } else { Write-Output 'not-found' }",
+            "capture_output": "signtool_path",
+            "timeout": 30
+        },
+        {
+            "desc": "Verify @driver_module@ catalog integrity via signtool",
+            "guest_run_file": "lib/engines/functest/tests/scripts/verify_driver_signtool.ps1",
+            "expected_output_contains": "PASS:",
+            "timeout": 90
+        }
+    ]
+}

--- a/lib/engines/functest/tests/scripts/verify_driver_package.ps1
+++ b/lib/engines/functest/tests/scripts/verify_driver_package.ps1
@@ -1,0 +1,37 @@
+# Verify the @driver_module@ driver package Authenticode signatures before installation.
+# Checks .sys, .cat, and .inf in @driver_dir@ — fails if any signature is invalid.
+
+$ErrorActionPreference = 'Stop'
+
+$module = '@driver_module@'
+$driverDir = '@driver_dir@'
+
+$sys = Get-ChildItem $driverDir -Filter "$module.sys" | Select-Object -First 1
+if (-not $sys) { throw "$module.sys not found in $driverDir" }
+
+$inf = Get-ChildItem $driverDir -Filter "$module.inf" | Select-Object -First 1
+if (-not $inf) { throw "$module.inf not found in $driverDir" }
+
+$catLine = Select-String -Path $inf.FullName -Pattern '^\s*CatalogFile\s*=' |
+    Select-Object -First 1
+if (-not $catLine) { throw "CatalogFile entry not found in $($inf.Name)" }
+
+$catName = ($catLine.Line -replace '^\s*CatalogFile\s*=\s*', '').Trim()
+$cat = Get-ChildItem $driverDir -Filter $catName | Select-Object -First 1
+if (-not $cat) { throw "$catName not found in $driverDir" }
+
+Write-Output "Package contents: $($sys.Name), $($inf.Name), $($cat.Name)"
+
+$catSig = Get-AuthenticodeSignature $cat.FullName
+Write-Output "Catalog signature: $($catSig.Status) — $($catSig.SignerCertificate.Subject)"
+if ($catSig.Status -ne 'Valid') {
+    throw "$($cat.Name) is NOT signed (status: $($catSig.Status))"
+}
+
+$sysSig = Get-AuthenticodeSignature $sys.FullName
+Write-Output "Driver signature: $($sysSig.Status) — $($sysSig.SignerCertificate.Subject)"
+if ($sysSig.Status -ne 'Valid') {
+    throw "$($sys.Name) is NOT signed (status: $($sysSig.Status))"
+}
+
+Write-Output 'PASS: Driver package Authenticode signatures verified'

--- a/lib/engines/functest/tests/scripts/verify_driver_signtool.ps1
+++ b/lib/engines/functest/tests/scripts/verify_driver_signtool.ps1
@@ -1,0 +1,44 @@
+# Verify the @driver_module@ driver package catalog integrity using signtool.
+# Validates .sys and .inf hashes match the .cat catalog — fails if signtool is missing.
+
+$ErrorActionPreference = 'Stop'
+
+$module = '@driver_module@'
+$driverDir = '@driver_dir@'
+$signtoolPath = '@signtool_path@'
+
+if (-not (Test-Path $signtoolPath)) {
+    throw "signtool not found at: $signtoolPath"
+}
+
+$sys = Get-ChildItem $driverDir -Filter "$module.sys" | Select-Object -First 1
+if (-not $sys) { throw "$module.sys not found in $driverDir" }
+
+$inf = Get-ChildItem $driverDir -Filter "$module.inf" | Select-Object -First 1
+if (-not $inf) { throw "$module.inf not found in $driverDir" }
+
+$catLine = Select-String -Path $inf.FullName -Pattern '^\s*CatalogFile\s*=' |
+    Select-Object -First 1
+if (-not $catLine) { throw "CatalogFile entry not found in $($inf.Name)" }
+
+$catName = ($catLine.Line -replace '^\s*CatalogFile\s*=\s*', '').Trim()
+$cat = Get-ChildItem $driverDir -Filter $catName | Select-Object -First 1
+if (-not $cat) { throw "$catName not found in $driverDir" }
+
+Write-Output "Using signtool: $signtoolPath"
+
+$out = & $signtoolPath verify /v /pa /c $cat.FullName $sys.FullName 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Output ($out | Out-String)
+    throw "signtool verify failed for $($sys.Name) against $($cat.Name)"
+}
+Write-Output "signtool: $($sys.Name) hash matches catalog"
+
+$out = & $signtoolPath verify /v /pa /c $cat.FullName $inf.FullName 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Output ($out | Out-String)
+    throw "signtool verify failed for $($inf.Name) against $($cat.Name)"
+}
+Write-Output "signtool: $($inf.Name) hash matches catalog"
+
+Write-Output 'PASS: Driver package catalog cross-check verified'


### PR DESCRIPTION
With https://github.com/HCK-CI/AutoHCK/commit/2f277e0e82e72e535f79d102e481048af6784ecc landing tests have the capacity to install signtool to extend signature verification.

Previously only checked the .sys Authenticode signature. Now also verifies the .cat catalog signature and, when signtool is available via @signtool_path@, cross-checks .sys and .inf hashes against the catalog. Degrades gracefully when signtool is not configured.  Test case json would need to provide expected path to the signtool e.g.:
```
  {
      "name": "driver_sign_check",
      "description": "Verify @driver_module@ driver package signature (.sys, .cat, .inf)",
      "test_system_ref": "VIRT-VSOCK-005",
      "timeout": 60,
      "test_steps": [
          {
              "desc": "Verify driver package signature",
              "guest_run_file": "lib/engines/functest/tests/scripts/verify_driver_signed.ps1",
              "expected_output_contains": "PASS:",
              "timeout": 30,
              "variables": {
                  "@signtool_path@": "@sw_path@\\Signtool_amd64_HLK.exe"
              }
          }
      ]
  }
```