### PR TITLE
[Functest engine] Add multi-client support

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -178,6 +178,7 @@ A test case defines an ordered sequence of steps and optional cleanup steps. Cas
 | `cycles` | No | Allow to repeat test_steps several times |
 | `test_steps` | Yes | Ordered array of step objects; a failure aborts remaining steps |
 | `cleanup` | No | Steps run after test completes (pass or fail); errors here do not change test status |
+| `clients` | No | Client ids (e.g. `[1, 2]`) this test case needs booted. Default: `[1]`. See [Multi-Client Support](#multi-client-support). |
 
 ### Example
 
@@ -205,9 +206,10 @@ See [`lib/engines/functest/tests/cases/driver_sign_check.json`](../lib/engines/f
 | `timeout` | Step timeout in seconds; overrides the engine default of 300s. |
 | `ignore_errors` | If `true`, a failure in this step does not abort the test. Useful for optional steps in `test_steps`. Default: `false`. |
 | `variables` | Maps `@placeholder@` strings to existing context variable names for extra substitution within this step. |
-| `capture_output` | Name of a variable to store the step's output in. For example, `"capture_output": "driver_version"` stores the output and makes it available as `@driver_version@` in subsequent steps. Supported by `guest_run`/`guest_run_file`, `qmp_command`, and `qmp_wait_event`. |
-| `expected_output_contains` | The step fails if the command output does not contain this exact string. Only supported by `guest_run`/`guest_run_file`. |
-| `expected_output_matches` | The step fails if the command output does not match this regex pattern. Only supported by `guest_run`/`guest_run_file`. |
+| `capture_output` | Name of a variable to store the step's output in, e.g. `"capture_output": "driver_version"` makes it available as `@driver_version@` later. Supported by `guest_run`/`guest_run_file`, `qmp_command`, `qmp_wait_event`. On a multi-client step, only the primary target's output is captured. |
+| `expected_output_contains` | The step fails if the output does not contain this string. Only for `guest_run`/`guest_run_file`. Checked against every client the step ran on. |
+| `expected_output_matches` | The step fails if the output does not match this regex. Only for `guest_run`/`guest_run_file`. Checked against every client the step ran on. |
+| `clients` | Client ids (e.g. `[2]`) this step targets. Applies to `guest_run`/`guest_run_file`, `guest_reboot`, `files_action`, `qmp_command`, `qmp_wait_event`; `host_run`/`host_run_file` always run once on the host regardless. Omitted/empty broadcasts to every client booted for the test case. See [Multi-Client Support](#multi-client-support). |
 
 ---
 
@@ -364,7 +366,35 @@ Blocks until one of the given QEMU events is received from the client VM. `event
 
 ### `barrier`
 
-A named synchronization point. In the current single-VM implementation it only logs the barrier name and does nothing else. Reserved for future multi-VM support.
+A named synchronization point. It only logs the barrier name and does nothing else.
+
+---
+
+## Multi-Client Support
+
+A test case can declare multiple clients via its top-level `clients` field, and a step can target one of them via its own `clients` field. Both use plain client ids (`1`, `2`, ...), mapped by position to the platform JSON's `clients` map — id `1` is its 1st entry, `2` its 2nd, etc. That entry's `name` (`CL1`, etc.) is the actual VM.
+
+```json
+{
+    "name": "multi_client_example",
+    "clients": [1, 2],
+    "test_steps": [
+        {
+            "desc": "Runs only on client 1",
+            "clients": [1],
+            "guest_run": "Write-Output 'hello from client 1'"
+        },
+        {
+            "desc": "Runs on every client booted for this test case",
+            "guest_run": "Write-Output 'hello from everyone'"
+        }
+    ]
+}
+```
+
+- `clients` defaults to `[1]`, so existing single-client tests are unaffected. `FunctestEngine` boots the union of `clients` across every selected test, once, up front.
+- A step's `clients` must be a subset of its test case's `clients`, and each id's corresponding role (`"c<id>"`) must be declared in the platform JSON — otherwise the step fails.
+- `capture_output` stores only the primary target's output; `expected_output_contains`/`expected_output_matches` are checked against every machine the step ran on.
 
 ---
 
@@ -385,6 +415,7 @@ These are populated automatically from CLI arguments and driver configuration:
 | `@test_binaries_path@` | Local host path to test binaries content (`--test-binaries-path` CLI option); see [Device-only testing](#device-only-testing) |
 | `@test_binaries_dir@` | Guest path where `--test-binaries-path` content was uploaded (`C:\AutoHCK\test_binaries`) |
 | `@spare_pcie_root_port_N@` (`N` = `0`, `1`, ...) | Bus id of the Nth spare, empty `pcie-root-port` allocated at boot via `--pcie-spare-root-ports <N>` (e.g. `@spare_pcie_root_port_0@` → `root2.0`). The max value of `N` depends on QEMU |
+| `@client_id@` | Zero-padded client id (e.g. `01`, `02`). Varies per target machine in `guest_run`/`guest_run_file`/`files_action`. |
 
 ### Step-level Variable Overrides
 

--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -60,6 +60,17 @@ module AutoHCK
       @reboot_strategy = init_opts[:reboot_strategy]
       @reboot_callback = init_opts[:reboot_callback]
       @default_timeout = init_opts[:default_timeout]
+
+      # Default machines for a step with no `clients` field; narrowed per
+      # test case by #scope_to_test.
+      @scoped_machines = @machines
+    end
+
+    # Sets the default machines to one test case's own clients. Call once
+    # per test case, before its steps run.
+    sig { params(client_ids: T::Array[Integer]).void }
+    def scope_to_test(client_ids)
+      @scoped_machines = client_ids.map { |client_id| resolve_client_name(client_id) }.uniq
     end
 
     sig do
@@ -74,7 +85,7 @@ module AutoHCK
       result = T.let({ desc: desc }, T::Hash[Symbol, T.untyped])
 
       result[:guest_outputs] = execute_guest(command_info, replacement, desc) if guest_command?(command_info)
-      execute_guest_reboot(desc) if command_info.guest_reboot
+      execute_guest_reboot(command_info, desc) if command_info.guest_reboot
       execute_host(command_info, replacement, desc) if host_command?(command_info)
       execute_files_actions(command_info, replacement) unless command_info.files_action.empty?
       execute_barrier(command_info) if command_info.barrier
@@ -90,7 +101,39 @@ module AutoHCK
       @project.project_replacement_map.merge(@project.setup_manager.client_replacement_map(machine_name))
     end
 
+    # Turns a step's `clients` ids into real machine names. If empty,
+    # uses the current test case's default machines instead.
+    sig { params(command_info: Models::CommandInfo).returns(T::Array[String]) }
+    def target_machines(command_info)
+      return @scoped_machines if command_info.clients.empty?
+
+      command_info.clients.map { |client_id| resolve_client_name(client_id) }.uniq
+    end
+
+    # The step's main target machine, used for capture_output: its first
+    # `clients` entry, or the first machine in scope if broadcasting.
+    sig { params(command_info: Models::CommandInfo).returns(T.nilable(String)) }
+    def primary_machine(command_info)
+      target_machines(command_info).first
+    end
+
     private
+
+    sig { params(client_id: Integer).returns(String) }
+    def resolve_client_name(client_id)
+      client = @project.engine_platform.client_for_id(client_id)
+      unless client
+        raise EngineError, "Step targets unknown client id #{client_id} " \
+                           '(not declared in the platform configuration)'
+      end
+
+      name = client.name
+      unless @machines.include?(name)
+        raise EngineError, "Step targets client #{client_id} (#{name}), which was not booted for this run"
+      end
+
+      name
+    end
 
     sig { params(command_info: Models::CommandInfo).returns(String) }
     def command_desc(command_info)
@@ -117,7 +160,7 @@ module AutoHCK
     def execute_guest(command_info, replacement, desc)
       outputs = {}
 
-      @machines.each do |machine_name|
+      target_machines(command_info).each do |machine_name|
         @logger.info("Running command (#{desc}) on client #{machine_name}")
         command = resolve_guest_command(command_info, machine_name, replacement)
         @logger.debug("Running command after replacement (#{desc}) on client #{machine_name}: #{command}")
@@ -128,9 +171,9 @@ module AutoHCK
       outputs
     end
 
-    sig { params(desc: String).void }
-    def execute_guest_reboot(desc)
-      @machines.each do |machine_name|
+    sig { params(command_info: Models::CommandInfo, desc: String).void }
+    def execute_guest_reboot(command_info, desc)
+      target_machines(command_info).each do |machine_name|
         reboot_machine(machine_name, desc)
       end
     end
@@ -157,7 +200,7 @@ module AutoHCK
           next
         end
 
-        @machines.each do |machine_name|
+        target_machines(command_info).each do |machine_name|
           action = prepare_file_action(files_action, machine_name, replacement, command_info)
           @file_action_handler.handle(machine_name, action)
         end
@@ -181,7 +224,7 @@ module AutoHCK
 
     sig { params(command_info: Models::CommandInfo).void }
     def execute_barrier(command_info)
-      @logger.info("Barrier: #{command_info.barrier} (single-VM mode, no-op)")
+      @logger.info("Barrier: #{command_info.barrier} (no-op)")
     end
 
     def run_qmp_command(execute, arguments, machine_name)
@@ -213,7 +256,7 @@ module AutoHCK
       execute = qmp.execute
 
       outputs = {}
-      @machines.each do |machine_name|
+      target_machines(command_info).each do |machine_name|
         map = replacement_map_for(machine_name, replacement, command_info)
         arguments = qmp.arguments && coerce_numeric_qmp_values(map.replace(qmp.arguments))
         outputs[machine_name] = run_qmp_command(execute, arguments, machine_name)
@@ -242,7 +285,7 @@ module AutoHCK
       events_desc = events.join("' or '")
 
       outputs = {}
-      @machines.each do |machine_name|
+      target_machines(command_info).each do |machine_name|
         outputs[machine_name] = run_qmp_wait_event(events, machine_name, timeout)
       rescue QMPError => e
         raise EngineError, "QMP event '#{events_desc}' wait failed on #{machine_name}: #{e.message}"
@@ -288,7 +331,7 @@ module AutoHCK
     end
     def replacement_map_for(machine_name, replacement, command_info)
       apply_variables(
-        machine_replacement_map(machine_name).merge(replacement),
+        replacement.merge(machine_replacement_map(machine_name)),
         command_info.variables
       )
     end

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -84,12 +84,17 @@ module AutoHCK
     # rubocop:disable Metrics/AbcSize
     def run
       @logger.info('Starting functest engine')
+      validate_tests_selected!
 
       ResourceScope.open do |scope|
-        client = @project.setup_manager.run_functest_client(scope, client_name)
-        client.prepare_machine
+        clients = boot_clients(scope)
+        raise AutoHCKError, 'No clients booted for the selected tests' if clients.empty?
 
-        @executor = Functest::TestExecutor.new(@project, client,
+        tools = build_tools(clients)
+        prepare_clients(clients, tools)
+        command_execution_manager = build_command_execution_manager(tools, clients)
+
+        @executor = Functest::TestExecutor.new(@project, clients, tools, command_execution_manager,
                                                default_timeout: @config['default_timeout'])
         setup_test_context(@executor.context)
         summary = @executor.execute_tests(@tests)
@@ -106,11 +111,56 @@ module AutoHCK
 
     private
 
-    def client_name
-      name = @project.engine_platform.clients.values.first&.name
-      raise AutoHCKError, 'No client found in platform configuration' unless name
+    # Stops early with a clear error if no tests were selected. Without
+    # this, boot_clients would boot zero clients and crash later.
+    def validate_tests_selected!
+      return unless @tests.empty?
 
-      name
+      raise AutoHCKError, 'No tests selected to run (check --category/--testcase and ' \
+                          '--select-test-names/--reject-test-names filters)'
+    end
+
+    # All client ids needed by the selected tests, combined and
+    # de-duplicated, in the order first seen.
+    def client_ids
+      @tests.flat_map(&:clients).uniq
+    end
+
+    def boot_clients(scope)
+      platform = @project.engine_platform
+
+      client_ids.map do |client_id|
+        client = platform.client_for_id(client_id)
+        unless client
+          raise AutoHCKError, "Test(s) require client #{client_id}, which is not declared " \
+                              'in the platform configuration'
+        end
+
+        @project.setup_manager.run_functest_client(scope, client.name)
+      end
+    end
+
+    # One FunctestTools instance, shared by every booted client.
+    def build_tools(clients)
+      clients_addrs = clients.to_h { |client| [client.name, client.winrm_addr] }
+      FunctestTools.new(@project, clients_addrs)
+    end
+
+    # Gets every client ready (wait online, install software/drivers)
+    def prepare_clients(clients, tools)
+      threads = clients.map { |client| Thread.new { client.prepare_machine(tools) } }
+      threads.each(&:join)
+    end
+
+    def build_command_execution_manager(tools, clients)
+      CommandExecutionManager.new(
+        project: @project,
+        tools: tools,
+        machines: clients.map(&:name),
+        init_opts: {
+          reboot_strategy: CommandExecutionManager::RebootStrategy[:WinrmPoll]
+        }
+      )
     end
 
     def load_tests(loader)

--- a/lib/engines/functest/functest_tools.rb
+++ b/lib/engines/functest/functest_tools.rb
@@ -15,8 +15,8 @@ module AutoHCK
     WAIT_WINRM_TIMEOUT = 600
     WAIT_WINRM_INTERVAL = 10
 
-    def initialize(project, client_name, winrm_addr)
-      super(project, no_studio: true, clients_addrs: { client_name => winrm_addr })
+    def initialize(project, clients_addrs)
+      super(project, no_studio: true, clients_addrs: clients_addrs)
     end
 
     # Restart the VM and block until WinRM is reachable again.

--- a/lib/engines/functest/step_handler.rb
+++ b/lib/engines/functest/step_handler.rb
@@ -7,10 +7,9 @@ module AutoHCK
     class StepHandler
       STEP_TYPE_FIELDS = CommandExecutionManager::STEP_TYPE_FIELDS
 
-      def initialize(project, command_execution_manager, machine_name, context, default_timeout:)
+      def initialize(project, command_execution_manager, context, default_timeout:)
         @project = project
         @command_execution_manager = command_execution_manager
-        @machine_name = machine_name
         @context = context
         @logger = project.logger
         @default_timeout = default_timeout
@@ -66,39 +65,63 @@ module AutoHCK
       end
 
       def handle_step_result(result, step)
-        output = guest_output(result)
-        @logger.debug("Guest output:\n#{output}") unless output.strip.empty?
+        primary_output = guest_output(result, step)
+        @logger.debug("Guest output:\n#{primary_output}") unless primary_output.strip.empty?
 
         if step.capture_output
-          captured = capture_value(result, output)
+          captured = capture_value(result, primary_output, step)
           @context.set_variable(step.capture_output, captured)
           @logger.debug("Captured '#{step.capture_output}': #{captured.to_s[0..100]}")
         end
 
-        validate_output(output, step)
+        validate_outputs(result, step)
       end
 
-      def guest_output(result)
-        result.fetch(:guest_outputs, {}).fetch(@machine_name, '').to_s
+      def guest_outputs(result)
+        result.fetch(:guest_outputs, {})
       end
 
-      def capture_value(result, guest_output)
+      # Only used by capture_output, since it can only store one value.
+      # expected_output_contains/matches don't use this — they use
+      # #validate_outputs instead, to check every target machine.
+      def guest_output(result, step)
+        machine = @command_execution_manager.primary_machine(step)
+        guest_outputs(result).fetch(machine, '').to_s
+      end
+
+      # qmp_result/qmp_event are keyed by machine name, so pick out the
+      # primary machine's value instead of capturing every machine's.
+      def capture_value(result, guest_output, step)
         return guest_output.strip unless guest_output.strip.empty?
-        return result[:qmp_result].to_json if result[:qmp_result]
-        return result[:qmp_event].to_json if result[:qmp_event]
+
+        machine = @command_execution_manager.primary_machine(step)
+        return result[:qmp_result][machine].to_json if result[:qmp_result]
+        return result[:qmp_event][machine].to_json if result[:qmp_event]
 
         ''
       end
 
-      def validate_output(output, step)
+      # Checks expected_output_contains/matches on every machine the step
+      # ran on. If any one of them fails, the step fails.
+      def validate_outputs(result, step)
+        outputs = guest_outputs(result)
+        return validate_output('', step) if outputs.empty?
+
+        outputs.each { |machine, output| validate_output(output.to_s, step, machine) }
+      end
+
+      def validate_output(output, step, machine = nil)
+        target = machine ? " on #{machine}" : ''
         if step.expected_output_contains && !output.include?(step.expected_output_contains)
-          raise EngineError, "Output validation failed: expected to contain '#{step.expected_output_contains}'"
+          raise EngineError, "Output validation failed#{target}: expected to contain '#{step.expected_output_contains}'"
         end
 
         return unless step.expected_output_matches
 
         pattern = Regexp.new(step.expected_output_matches)
-        raise EngineError, "Output validation failed: expected to match '#{pattern}'" unless output.match?(pattern)
+        return if output.match?(pattern)
+
+        raise EngineError, "Output validation failed#{target}: expected to match '#{pattern}'"
       end
 
       def handle_step_error(step, error_message)

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -17,6 +17,10 @@ module AutoHCK
       prop :test_steps, T::Array[Models::CommandInfo]
       const :cleanup, T::Array[Models::CommandInfo], default: []
 
+      # Client ids (e.g. 1, 2) this test case needs booted, by position in
+      # the platform JSON's clients map.
+      const :clients, T::Array[Integer], default: [1]
+
       sig { returns(String) }
       def safe_name
         name.gsub(/[^\w\-.]/, '_').gsub(/(^_|_$)/, '')

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -12,15 +12,17 @@ module AutoHCK
         @results.map { |r| Models::TestResult.from_functest(r) }
       end
 
-      def initialize(project, client, default_timeout:)
+      # clients is every FunctestClient booted for this run. tools and
+      # command_execution_manager are shared by all of them.
+      def initialize(project, clients, tools, command_execution_manager, default_timeout:)
         @project = project
-        @client = client
-        @tools = client.tools
-        @machine_name = client.name
+        @clients = clients
+        @tools = tools
+        @machine_names = clients.map(&:name)
         @logger = project.logger
-        @context = TestContext.new(project, client.replacement_map)
-        @command_execution_manager = client.command_execution_manager
-        @step_handler = StepHandler.new(project, @command_execution_manager, @machine_name, @context,
+        @context = TestContext.new(project, clients.first.replacement_map)
+        @command_execution_manager = command_execution_manager
+        @step_handler = StepHandler.new(project, @command_execution_manager, @context,
                                         default_timeout: default_timeout)
         @results = []
         @current_test = nil
@@ -81,7 +83,8 @@ module AutoHCK
           pre_test_commands: test.pre_test_commands.map(&:dup),
           cycles: test.cycles,
           test_steps: test.test_steps.map(&:dup),
-          cleanup: test.cleanup.map(&:dup)
+          cleanup: test.cleanup.map(&:dup),
+          clients: test.clients.dup
         ).tap do |test_local|
           test_local.add_auto_index
           test_local.apply_cycles_to_steps
@@ -128,6 +131,7 @@ module AutoHCK
       end
 
       def run_test_steps(test, result)
+        prepare_test_clients!(test)
         run_pre_test_commands(test)
         test.test_steps.each_with_index { |step, index| result[:steps] << execute_test_step(step, index) }
         result[:status] = 'passed'
@@ -136,6 +140,27 @@ module AutoHCK
         result[:status] = 'failed'
         result[:error] = e.message
         @logger.error("FAILED: #{test.name} - #{e.message}")
+      end
+
+      # Sets CommandExecutionManager's default machines to this test's own
+      # clients. Then fails the test right away if any step (including
+      # pre_test_commands and cleanup) targets a client this test didn't
+      # declare.
+      def prepare_test_clients!(test)
+        raise EngineError, "Test '#{test.name}' has an empty clients list" if test.clients.empty?
+
+        @command_execution_manager.scope_to_test(test.clients)
+        validate_step_clients!(test)
+      end
+
+      def validate_step_clients!(test)
+        (test.pre_test_commands + test.test_steps + test.cleanup).each do |step|
+          unknown = step.clients - test.clients
+          next if unknown.empty?
+
+          raise EngineError, "Test '#{test.name}' step targets client(s) #{unknown.join(', ')} not declared " \
+                             "in this test case's own clients list (#{test.clients.join(', ')})"
+        end
       end
 
       def execute_test_step(step, index)
@@ -194,7 +219,7 @@ module AutoHCK
 
       def collect_memory_dumps(test_name)
         id = test_name.gsub(/\W/, '_')
-        MemoryDumpCollector.new(@tools, [@machine_name], @project.workspace_path, @logger).collect(id)
+        MemoryDumpCollector.new(@tools, @machine_names, @project.workspace_path, @logger).collect(id)
       end
     end
   end

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -83,6 +83,11 @@ module AutoHCK
 
       const :expected_output_contains, T.nilable(String)
       const :expected_output_matches, T.nilable(String)
+
+      # Client ids (e.g. 1, 2) this step targets, by position in the platform
+      # JSON's clients map. Empty (default) broadcasts to every client in
+      # the current test case.
+      const :clients, T::Array[Integer], default: []
     end
   end
 end

--- a/lib/models/hlk_platform.rb
+++ b/lib/models/hlk_platform.rb
@@ -60,6 +60,13 @@ module AutoHCK
       const :clients, T::Hash[String, HLKClient]
       const :extra_software, T::Array[String], default: []
 
+      # client_id is the client's 1-based position in the clients map.
+      sig { params(client_id: Integer).returns(T.nilable(HLKClient)) }
+      def client_for_id(client_id)
+        role_id = clients.keys[client_id - 1]
+        role_id && clients[role_id]
+      end
+
       sig { params(hash: T::Hash[String, T.untyped], strict: T::Boolean).void }
       # This is Sorbet function, so we can't change the signature
       # rubocop:disable Style/OptionalBooleanParameter

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -7,7 +7,7 @@ module AutoHCK
   class FunctestClient
     TEST_BINARIES_REMOTE_PATH = 'C:\\AutoHCK\\test_binaries'
 
-    attr_reader :name, :tools, :replacement_map
+    attr_reader :name, :tools, :replacement_map, :winrm_addr
 
     def initialize(setup_manager, scope, name, run_opts = nil)
       @project = setup_manager.project
@@ -18,29 +18,19 @@ module AutoHCK
       @runner = setup_manager.run_client(scope, name, run_opts)
       scope << self
       @replacement_map = @project.project_replacement_map.merge(setup_manager.client_replacement_map(name))
+      @winrm_addr = lookup_winrm_addr
     end
 
-    def prepare_machine
+    # tools is a FunctestTools instance shared by every client booted this
+    # run. FunctestEngine builds it.
+    def prepare_machine(tools)
       @logger.info("Preparing client #{@name}...")
-      @tools = FunctestTools.new(@project, @name, client_winrm_addr)
+      @tools = tools
       @tools.wait_for_client_online(@name)
       @project.extra_sw_manager.install_software_before_driver(@tools, @name)
       install_drivers
       copy_test_binaries
       @project.extra_sw_manager.install_software_after_driver(@tools, @name)
-    end
-
-    def command_execution_manager
-      raise AutoHCKError, 'Tools not initialized; call prepare_machine first' unless @tools
-
-      @command_execution_manager ||= CommandExecutionManager.new(
-        project: @project,
-        tools: @tools,
-        machines: [@name],
-        init_opts: {
-          reboot_strategy: CommandExecutionManager::RebootStrategy[:WinrmPoll]
-        }
-      )
     end
 
     def close
@@ -49,12 +39,12 @@ module AutoHCK
 
     private
 
-    def client_winrm_addr
+    def lookup_winrm_addr
       client = @project.engine_platform.clients.values.find { |c| c.name == @name }
       raise AutoHCKError, "No platform client entry found for #{@name}" unless client
       raise AutoHCKError, "winrm_addr missing for client #{@name} in platform config" unless client.winrm_addr
 
-      { addr: client.winrm_addr }
+      { addr: client.winrm_addr, port: client.winrm_port }
     end
 
     def insert_driver_replacement(driver, replacement)

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -150,7 +150,19 @@ module AutoHCK
     MONITOR_BASE_PORT = 10_000
     VNC_BASE_PORT = 5900
     MAX_RUN_ID = 999
-    MAX_CLIENT_ID = 2
+    # https://learn.microsoft.com/en-us/windows-hardware/test/hlk/testref/test-server-configuration
+    # 0 - Studio
+    # 1 - Active Directory (SVVP-only but mandatory)
+    # 2 - SUT / DUT
+    # 3 - Master client / Support client for DUT
+    # 4 - Stress Client 1
+    # 5 - Stress Client 2
+    # 6 - Stress Client 3
+    # 7 - Stress Client 4
+    # 8 - Stress Client 5
+    # 9 - Stress Client 6
+    # 10 - Stress Client 7 (LoadGen supports up to 64 SC machines, but 8 is usually sufficient, QE uses 4)
+    MAX_CLIENT_ID = 10
 
     DEFAULT_RUN_OPTIONS = {
       keep_alive: false,


### PR DESCRIPTION
Adds the base support for functional tests that need more than one
client VM.

- Raise the max number of clients to 10.
- Tests can now say which clients they need, and steps can target a
  specific client or all of them.
- The engine boots all clients a test needs and runs steps on the
  right ones.
  
  Existing single-client tests are not affected.