### PR TITLE
QemuHCK: add --discard-granularity CLI option for virtio-blk-pci

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -94,6 +94,8 @@ Usage: auto_hck.rb test [test options]
                                      Has effect only when testing storage drivers.
         --aio-native                  Use aio=native for virtual disks (forces cache=none, cannot combine with --aio-threads)
         --aio-threads                 Use aio=threads for virtual disks (forces cache=none, cannot combine with --aio-native)
+        --discard-granularity <size>  Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive
+                                     Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)
         --extensions <extensions_list>
                                      List of extensions for run test
         --net-test-speed <net_test_speed>

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -113,6 +113,7 @@ module AutoHCK
     prop :category, T.nilable(String)
     prop :testcase, T.nilable(String)
     prop :drive_aio_state, T.nilable(String)
+    prop :discard_granularity, T.nilable(String)
 
     def aio_native=(value)
       raise(AutoHCKError, '--aio-native cannot be combined with --aio-threads') if value && drive_aio_state == 'threads'
@@ -307,6 +308,11 @@ module AutoHCK
       parser.on('--aio-threads', TrueClass,
                 'Use aio=threads for virtual disks (forces cache=none, cannot combine with --aio-native)',
                 &method(:aio_threads=))
+
+      parser.on('--discard-granularity <size>', String,
+                'Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive',
+                'Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)',
+                &method(:discard_granularity=))
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end

--- a/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
@@ -10,8 +10,8 @@
     "@source@/bin/fake-snmp-reset @blk_qmp_socket@ &"
   ],
   "command_line": [
-    "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_blk_@run_id@_@client_id@@drive_cache_options@",
-    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@,serial=@client_id@blk@run_id@@bootindex@",
+    "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_blk_@run_id@_@client_id@@drive_cache_options@@drive_discard_param@",
+    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@@blk_discard_granularity_param@,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@,serial=@client_id@blk@run_id@@bootindex@",
     "-chardev socket,id=blk_qmp,path=@blk_qmp_socket@,server=on,wait=off",
     "-mon chardev=blk_qmp,mode=control"
   ]

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -307,7 +307,6 @@ module AutoHCK
       @states_config.each { |name, state| apply_state name, state }
       apply_drive_aio_state
       validate_drive_aio_state
-
       apply_cpu_options_config
     end
 
@@ -390,6 +389,29 @@ module AutoHCK
       }
     end
 
+    DISCARD_GRANULARITY_FORMAT = /\A(\d+)([KMG])?\z/i
+    DISCARD_GRANULARITY_UNITS = { 'K' => 1024, 'M' => 1024**2, 'G' => 1024**3 }.freeze
+
+    # Sets discard=unmap and discard_granularity (in bytes) on the virtio-blk-pci
+    # device, when the discard_granularity option is configured.
+    def discard_granularity_replacement_map
+      value = option_config('discard_granularity')
+      return { '@drive_discard_param@' => '', '@blk_discard_granularity_param@' => '' } if value.nil?
+
+      match = DISCARD_GRANULARITY_FORMAT.match(value.to_s)
+      unless match
+        raise QemuHCKError, "discard_granularity value '#{value}' is invalid; " \
+                            'expected a size such as 4096, 4K, 256K, or 32M'
+      end
+
+      bytes = match[1].to_i * DISCARD_GRANULARITY_UNITS.fetch(match[2]&.upcase, 1)
+
+      {
+        '@drive_discard_param@' => ',discard=unmap',
+        '@blk_discard_granularity_param@' => ",discard_granularity=#{bytes}"
+      }
+    end
+
     sig { returns(T::Array[String]) }
     def device_config_commands
       @device_infos.map(&:config_commands).flatten.compact
@@ -433,6 +455,7 @@ module AutoHCK
                                              machine_replacement_map,
                                              memory_replacement_map,
                                              options_replacement_map,
+                                             discard_granularity_replacement_map,
                                              device_define_variables,
                                              @define_variables)
     end

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -93,6 +93,7 @@ module AutoHCK
       options
     end
 
+    # rubocop:disable Metrics/AbcSize
     def client_vm_common_options
       common = @project.options.common
       test_opt = @project.options.test
@@ -109,9 +110,11 @@ module AutoHCK
         'fs_test_image_format' => test_opt.fs_test_image_format,
         'net_test_speed' => test_opt.net_test_speed,
         'drive_aio_state' => test_opt.drive_aio_state,
+        'discard_granularity' => test_opt.discard_granularity,
         'ctrl_net_device' => common.client_ctrl_net_dev
       }.compact
     end
+    # rubocop:enable Metrics/AbcSize
 
     sig { params(client_info: Models::HLKClient, index: Integer).returns(T::Hash[String, T.untyped]) }
     def client_vm_options(client_info, index)


### PR DESCRIPTION
Add a --discard-granularity flag (plain byte count or K/M/G suffix, e.g. 4096, 4K, 256K, 32M). 
Sets discard=unmap on the drive and discard_granularity on the virtio-blk-pci device.
The value is converted to raw bytes before it reaches the QEMU command line.