### PR TITLE
QemuHCK: add --virtiofs-cache CLI option for virtio-fs cache mode

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -96,6 +96,7 @@ Usage: auto_hck.rb test [test options]
         --aio-threads                 Use aio=threads for virtual disks (forces cache=none, cannot combine with --aio-native)
         --discard-granularity <size>  Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive
                                      Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)
+        --virtiofs-cache <mode>       Set virtiofsd cache mode for the virtio-fs device (default: always)
         --extensions <extensions_list>
                                      List of extensions for run test
         --net-test-speed <net_test_speed>

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -114,6 +114,7 @@ module AutoHCK
     prop :testcase, T.nilable(String)
     prop :drive_aio_state, T.nilable(String)
     prop :discard_granularity, T.nilable(String)
+    prop :fs_daemon_cache_mode, T.nilable(String)
 
     def aio_native=(value)
       raise(AutoHCKError, '--aio-native cannot be combined with --aio-threads') if value && drive_aio_state == 'threads'
@@ -313,6 +314,10 @@ module AutoHCK
                 'Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive',
                 'Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)',
                 &method(:discard_granularity=))
+
+      parser.on('--virtiofs-cache <mode>', %w[auto always never],
+                'Set virtiofsd cache mode for the virtio-fs device (default: always)',
+                &method(:fs_daemon_cache_mode=))
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end

--- a/lib/setupmanagers/qemuhck/devices/vhost-user-fs-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/vhost-user-fs-pci.json
@@ -13,7 +13,7 @@
   "pre_start_commands": [
     "mkdir -p @fs_daemon_share_path@",
     "rm -f @fs_daemon_socket@",
-    "@source@/bin/unix_spawn @fs_daemon_socket@ @fs_daemon_bin@ --fd 3 -o source=@fs_daemon_share_path@ --cache always"
+    "@source@/bin/unix_spawn @fs_daemon_socket@ @fs_daemon_bin@ --fd 3 -o source=@fs_daemon_share_path@ --cache @fs_daemon_cache_mode@"
   ],
   "post_stop_commands": [
     "rm -f @fs_daemon_socket@"

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -412,6 +412,16 @@ module AutoHCK
       }
     end
 
+    FS_DAEMON_CACHE_MODES = %w[auto always never].freeze
+
+    # virtiofsd cache mode for the virtio-fs device; defaults to 'always'
+    def fs_daemon_cache_mode_replacement_map
+      mode = option_config('fs_daemon_cache_mode')
+      mode = 'always' unless FS_DAEMON_CACHE_MODES.include?(mode)
+
+      { '@fs_daemon_cache_mode@' => mode }
+    end
+
     sig { returns(T::Array[String]) }
     def device_config_commands
       @device_infos.map(&:config_commands).flatten.compact
@@ -456,6 +466,7 @@ module AutoHCK
                                              memory_replacement_map,
                                              options_replacement_map,
                                              discard_granularity_replacement_map,
+                                             fs_daemon_cache_mode_replacement_map,
                                              device_define_variables,
                                              @define_variables)
     end

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -111,6 +111,7 @@ module AutoHCK
         'net_test_speed' => test_opt.net_test_speed,
         'drive_aio_state' => test_opt.drive_aio_state,
         'discard_granularity' => test_opt.discard_granularity,
+        'fs_daemon_cache_mode' => test_opt.fs_daemon_cache_mode,
         'ctrl_net_device' => common.client_ctrl_net_dev
       }.compact
     end


### PR DESCRIPTION
virtiofsd's cache mode was hardcoded to "always". 
Add a --virtiofs-cache flag (auto/always/never) so it can be set per run. 
Default stays "always".