### PR TITLE
QemuHCK: Assign stable QEMU id to vhost-user-fs-pci device

### DIFF
--- a/lib/setupmanagers/qemuhck/devices/vhost-user-fs-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/vhost-user-fs-pci.json
@@ -5,7 +5,7 @@
     "-chardev socket,id=virtiofsid,path=@fs_daemon_socket@",
     "-object memory-backend-file,id=mem_backend,size=@memory@,mem-path=/dev/shm,share=on",
     "-numa node,memdev=mem_backend",
-    "-device vhost-user-fs-pci@device_extra_param@,queue-size=1024,chardev=virtiofsid,tag=myfs,bus=@bus_name@.0"
+    "-device vhost-user-fs-pci@device_extra_param@,id=viofs0,queue-size=1024,chardev=virtiofsid,tag=myfs,bus=@bus_name@.0"
   ],
   "define_variables": {
     "@fs_daemon_socket@": "fs_daemon_socket_@run_id@_@client_id@"


### PR DESCRIPTION
Give the boot vhost-user-fs-pci device a fixed id=viofs0 so QMP can address it by name.