### PR TITLE
Add id to virtio-blk-pci device definition

### DIFF
--- a/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
@@ -11,7 +11,7 @@
   ],
   "command_line": [
     "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_blk_@run_id@_@client_id@@drive_cache_options@@drive_discard_param@",
-    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@@blk_discard_granularity_param@,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@,serial=@client_id@blk@run_id@@bootindex@",
+    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@@blk_discard_granularity_param@,id=virtio_blk_dev,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@,serial=@client_id@blk@run_id@@bootindex@",
     "-chardev socket,id=blk_qmp,path=@blk_qmp_socket@,server=on,wait=off",
     "-mon chardev=blk_qmp,mode=control"
   ]


### PR DESCRIPTION
Add an explicit id to device virtio-blk-pci.  This would allow functest scripts to parse for the specific id and gather property information to validate configuration e.g.:

```
    "test_steps": [
          {
              "desc": "Set expected virtio mode",
              "guest_run": "Write-Output 'modern'",
              "capture_output": "expected_virtio_mode"
          },
          {
              "desc": "QMP: Query disable-legacy property",
              "qmp_command": {
                  "execute": "qom-get",
                  "arguments": {
                      "path": "/machine/peripheral/virtio_blk_dev",
                      "property": "disable-legacy"
                  }
              },
              "capture_output": "qemu_disable_legacy"
          },
          {
              "desc": "QMP: Query disable-modern property",
              "qmp_command": {
                  "execute": "qom-get",
                  "arguments": {
                      "path": "/machine/peripheral/virtio_blk_dev",
                      "property": "disable-modern"
                  }
              },
              "capture_output": "qemu_disable_modern"
          }
```
Output can be passed to follow up scripts to validate configuration. This is being done to keep in line with [tp-qemu](https://github.com/autotest/tp-qemu/blob/master/qemu/tests/cfg/virtio_mode.cfg#L9)'s testing approach which explicitly checks the relevant flags on the hypervisor side to confirm if the device is running in modern, legacy, or transitional.