### PR TITLE
QemuHCK: allocate spare pcie-root-ports for runtime hotplug

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -370,6 +370,7 @@ These are populated automatically from CLI arguments and driver configuration:
 | `@driver_name@` | Full driver name as defined in the driver JSON configuration |
 | `@test_binaries_path@` | Local host path to test binaries content (`--test-binaries-path` CLI option); see [Device-only testing](#device-only-testing) |
 | `@test_binaries_dir@` | Guest path where `--test-binaries-path` content was uploaded (`C:\AutoHCK\test_binaries`) |
+| `@spare_pcie_root_port_N@` (`N` = `0`, `1`, ...) | Bus id of the Nth spare, empty `pcie-root-port` allocated at boot via `--pcie-spare-root-ports <N>` (e.g. `@spare_pcie_root_port_0@` → `root2.0`). The max value of `N` depends on QEMU |
 
 ### Step-level Variable Overrides
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -97,6 +97,8 @@ Usage: auto_hck.rb test [test options]
         --discard-granularity <size>  Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive
                                      Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)
         --virtiofs-cache <mode>       Set virtiofsd cache mode for the virtio-fs device (default: always)
+        --pcie-spare-root-ports <N>   Allocate N extra empty pcie-root-ports at boot for later hotplug (q35 only, default: 0)
+                                     Max N depends on QEMU
         --extensions <extensions_list>
                                      List of extensions for run test
         --net-test-speed <net_test_speed>

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -115,6 +115,7 @@ module AutoHCK
     prop :drive_aio_state, T.nilable(String)
     prop :discard_granularity, T.nilable(String)
     prop :fs_daemon_cache_mode, T.nilable(String)
+    prop :pcie_spare_root_ports, T.nilable(Integer)
 
     def aio_native=(value)
       raise(AutoHCKError, '--aio-native cannot be combined with --aio-threads') if value && drive_aio_state == 'threads'
@@ -318,6 +319,11 @@ module AutoHCK
       parser.on('--virtiofs-cache <mode>', %w[auto always never],
                 'Set virtiofsd cache mode for the virtio-fs device (default: always)',
                 &method(:fs_daemon_cache_mode=))
+
+      parser.on('--pcie-spare-root-ports <N>', Integer,
+                'Allocate N extra empty pcie-root-ports at boot for later hotplug (q35 only, default: 0)',
+                'Max N depends on QEMU',
+                &method(:pcie_spare_root_ports=))
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -196,6 +196,7 @@ module AutoHCK
       @define_variables = {}
       @run_opts = {}
       @configured = false
+      @spare_pcie_root_ports = []
     end
 
     sig { returns(T::Array[Models::CommandInfo]) }
@@ -367,7 +368,15 @@ module AutoHCK
       ReplacementMap.new(@project.project_replacement_map, machine_replacement_map, {
                            '@client_id@' => @client_id,
                            '@test_netdev_id@' => @nm.test_device_ifname
-                         })
+                         }, spare_pcie_root_port_replacement_map)
+    end
+
+    # Exposes each spare pcie-root-port's bus id (e.g. @spare_pcie_root_port_0@ => "root5.0")
+    # so test steps (e.g. qmp_command device_add) can hotplug onto it.
+    def spare_pcie_root_port_replacement_map
+      @spare_pcie_root_ports.each_with_index.to_h do |bus_name, i|
+        ["@spare_pcie_root_port_#{i}@", "#{bus_name}.0"]
+      end
     end
 
     def memory_replacement_map
@@ -620,6 +629,31 @@ module AutoHCK
       @device_infos.each do |device_info|
         @logger.debug("Processing device: #{device_info.name}")
         process_device_command(device_info)
+      end
+
+      allocate_spare_pcie_root_ports
+    end
+
+    sig { returns(Integer) }
+    def pcie_spare_root_port_count
+      count = (option_config('pcie_spare_root_ports') || 0).to_i
+      return count if count.zero?
+
+      if @machine['pcie_root_port'].nil?
+        raise QemuHCKError, "pcie_spare_root_ports requires a PCIe-capable machine type (got '#{@machine_name}')"
+      end
+
+      count
+    end
+
+    # Creates empty pcie-root-ports with no device attached, so a later QMP
+    # device_add can hotplug onto a real bus instead of pcie.0 directly.
+    sig { void }
+    def allocate_spare_pcie_root_ports
+      @spare_pcie_root_ports = Array.new(pcie_spare_root_port_count) do
+        cmd, bus_name = @pcim.create_pci_root_port
+        @device_commands << cmd
+        bus_name
       end
     end
 

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -112,6 +112,7 @@ module AutoHCK
         'drive_aio_state' => test_opt.drive_aio_state,
         'discard_granularity' => test_opt.discard_granularity,
         'fs_daemon_cache_mode' => test_opt.fs_daemon_cache_mode,
+        'pcie_spare_root_ports' => test_opt.pcie_spare_root_ports,
         'ctrl_net_device' => common.client_ctrl_net_dev
       }.compact
     end


### PR DESCRIPTION
Add --pcie-spare-root-ports <N> to allocate N extra, empty pcie-root-port devices at boot (q35 only). Their bus ids are exposed as @spare_pcie_root_port_N@ placeholders, so a functest step can qmp_command device_add onto a real bus at runtime.