### PR TITLE
Add incremental dev id for virtio-blk-pci.json

### DIFF
--- a/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
@@ -10,8 +10,8 @@
     "@source@/bin/fake-snmp-reset @blk_qmp_socket@ &"
   ],
   "command_line": [
-    "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_blk_@run_id@_@client_id@@drive_cache_options@@drive_discard_param@",
-    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@@blk_discard_granularity_param@,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@,serial=@client_id@blk@run_id@@bootindex@",
+    "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_blk_@run_id@_@client_id@_@storage_dev_id@@drive_cache_options@@drive_discard_param@",
+    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@@blk_discard_granularity_param@,id=virtio_blk_@run_id@_@client_id@_@storage_dev_id@_dev,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@_@storage_dev_id@,serial=@client_id@blk@run_id@@bootindex@",
     "-chardev socket,id=blk_qmp,path=@blk_qmp_socket@,server=on,wait=off",
     "-mon chardev=blk_qmp,mode=control"
   ]

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -367,8 +367,10 @@ module AutoHCK
     def replacement_map
       ReplacementMap.new(@project.project_replacement_map, machine_replacement_map, {
                            '@client_id@' => @client_id,
-                           '@test_netdev_id@' => @nm.test_device_ifname
-                         }, spare_pcie_root_port_replacement_map)
+                           '@test_netdev_id@' => @nm.test_device_ifname,
+                           '@storage_dev_id@' => format('%02d', @sm.dev_id)
+                         }, device_define_variables,
+                         spare_pcie_root_port_replacement_map)
     end
 
     # Exposes each spare pcie-root-port's bus id (e.g. @spare_pcie_root_port_0@ => "root5.0")

--- a/lib/setupmanagers/qemuhck/storage_manager.rb
+++ b/lib/setupmanagers/qemuhck/storage_manager.rb
@@ -10,10 +10,13 @@ module AutoHCK
 
       IMAGE_FORMAT = 'qcow2'
 
+      attr_reader :dev_id
+
       def initialize(id, client_id, qemu_config, qemu_options, logger)
         @id = id
         @client_id = client_id
         @logger = logger
+        @dev_id = 0
 
         @workspace_path = qemu_options['workspace_path']
         @qemu_img_bin = qemu_config['qemu_img_bin']
@@ -26,8 +29,13 @@ module AutoHCK
       end
 
       def device_command_info(type, device, command_options, bus_name, qemu_replacement_map)
+        @dev_id += 1
+
         replacement_map = qemu_replacement_map.merge command_options
-        device_command = replacement_map.merge({ '@bus_name@' => bus_name }).create_cmd(device.command_line.join(' '))
+        device_command = replacement_map.merge({
+                                                 '@bus_name@' => bus_name,
+                                                 '@storage_dev_id@' => format('%02d', @dev_id)
+                                               }).create_cmd(device.command_line.join(' '))
 
         @logger.debug("Device #{device.name} used as #{type} device")
         @logger.debug("Device command: #{device_command}")


### PR DESCRIPTION
Building on the work from [1], updated storage_manager with a dev_id that increments on `device_command_info` call. Similar to [1], update the replacement_map function in `qemu_machine` to also include the formatted device id added to storage_manager. Lastly included new id value in `virtio-blk-pci.json` definition. Tested this downstream against a testcase that also analyzes for configuration properties from the virtio-blk device.

[1] [https://github.com/HCK-CI/AutoHCK/pull/1053](https://github.com/HCK-CI/AutoHCK/pull/1053)