### PR TITLE
Functest: Add cycles support

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -174,6 +174,8 @@ A test case defines an ordered sequence of steps and optional cleanup steps. Cas
 | `name` | Yes | Test case name; shown in results and log output |
 | `description` | No | Human-readable description |
 | `test_system_ref` | No | Reference to an issue or ticket |
+| `pre_test_commands` | No | Steps run before test start; a failure aborts remaining steps |
+| `cycles` | No | Allow to repeat test_steps several times |
 | `test_steps` | Yes | Ordered array of step objects; a failure aborts remaining steps |
 | `cleanup` | No | Steps run after test completes (pass or fail); errors here do not change test status |
 

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -12,6 +12,7 @@ module AutoHCK
       const :description, T.nilable(String)
       const :test_system_ref, T.nilable(String)
       const :timeout, T.nilable(Integer)
+      const :pre_test_commands, T::Array[Models::CommandInfo], default: []
       const :test_steps, T::Array[Models::CommandInfo]
       const :cleanup, T::Array[Models::CommandInfo], default: []
 

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -13,7 +13,8 @@ module AutoHCK
       const :test_system_ref, T.nilable(String)
       const :timeout, T.nilable(Integer)
       const :pre_test_commands, T::Array[Models::CommandInfo], default: []
-      const :test_steps, T::Array[Models::CommandInfo]
+      const :cycles, Integer, default: 1
+      prop :test_steps, T::Array[Models::CommandInfo]
       const :cleanup, T::Array[Models::CommandInfo], default: []
 
       sig { returns(String) }
@@ -30,6 +31,22 @@ module AutoHCK
         test_steps.each_with_index do |step, index|
           step.desc = "[Step #{index + 1}] #{step.desc}"
         end
+      end
+
+      sig { void }
+      def apply_cycles_to_steps
+        return if cycles <= 1
+
+        new_test_steps = []
+        cycles.times do |cycle|
+          test_steps.each do |step|
+            new_step = step.dup
+            new_step.desc = "[Cycle #{cycle + 1}] #{step.desc}"
+            new_test_steps << new_step
+          end
+        end
+
+        self.test_steps = new_test_steps
       end
     end
   end

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -20,6 +20,17 @@ module AutoHCK
       def safe_name
         name.gsub(/[^\w\-.]/, '_').gsub(/(^_|_$)/, '')
       end
+
+      sig { void }
+      def add_auto_index
+        pre_test_commands.each_with_index do |step, index|
+          step.desc = "[Pre-test step #{index + 1}] #{step.desc}"
+        end
+
+        test_steps.each_with_index do |step, index|
+          step.desc = "[Step #{index + 1}] #{step.desc}"
+        end
+      end
     end
   end
 end

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -110,6 +110,7 @@ module AutoHCK
       end
 
       def run_test_steps(test, result)
+        run_pre_test_commands(test)
         test.test_steps.each_with_index { |step, index| result[:steps] << execute_test_step(step, index) }
         result[:status] = 'passed'
         @logger.info("PASSED: #{test.name}")
@@ -146,6 +147,20 @@ module AutoHCK
         @logger.info('=' * 80)
         @logger.info(title)
         @logger.info('=' * 80)
+      end
+
+      def run_pre_test_commands(test)
+        return if test.pre_test_commands.empty?
+
+        @logger.info('Running pre-test commands...')
+        desc = nil
+        test.pre_test_commands.each_with_index do |step, index|
+          desc = @context.substitute_variables(step.desc)
+          @step_handler.execute_step(step, index)
+        rescue StandardError => e
+          @logger.error("  FAIL: Pre-test command failed (#{desc}): #{e.message}")
+          raise
+        end
       end
 
       def run_cleanup(test)

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -74,12 +74,14 @@ module AutoHCK
 
       def record_test(test)
         start_time = Time.now
-        @current_test = test.name
-        result = @results.find { |r| r[:name] == test.name }
-        raise EngineError, "Result placeholder not found for #{test.name}" unless result
+        test_name = test.name
+        @current_test = test_name
+        result = @results.find { |r| r[:name] == test_name }
+        raise EngineError, "Result placeholder not found for #{test_name}" unless result
 
         result.merge!({ status: 'running', steps: [], start_time: start_time.utc.iso8601 })
         @project.generate_result_report
+        test.add_auto_index
         run_test_steps(test, result)
         result
       ensure
@@ -121,7 +123,7 @@ module AutoHCK
       end
 
       def execute_test_step(step, index)
-        desc = @context.substitute_variables(step.desc || "Step #{index + 1}")
+        desc = @context.substitute_variables(step.desc)
         start_time = Time.now
         step_result = { index: index, description: desc, status: 'running', start_time: start_time.utc.iso8601 }
         run_step(step, index, step_result, desc)

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -72,6 +72,22 @@ module AutoHCK
           'currentcount' => passed + failed + 1, 'total' => total }
       end
 
+      def create_local_test_copy(test)
+        TestCase.new(
+          name: test.name,
+          description: test.description,
+          test_system_ref: test.test_system_ref,
+          timeout: test.timeout,
+          pre_test_commands: test.pre_test_commands.map(&:dup),
+          cycles: test.cycles,
+          test_steps: test.test_steps.map(&:dup),
+          cleanup: test.cleanup.map(&:dup)
+        ).tap do |test_local|
+          test_local.add_auto_index
+          test_local.apply_cycles_to_steps
+        end
+      end
+
       def record_test(test)
         start_time = Time.now
         test_name = test.name
@@ -81,8 +97,8 @@ module AutoHCK
 
         result.merge!({ status: 'running', steps: [], start_time: start_time.utc.iso8601 })
         @project.generate_result_report
-        test.add_auto_index
-        run_test_steps(test, result)
+        test_local = create_local_test_copy(test)
+        run_test_steps(test_local, result)
         result
       ensure
         finalize_result(result, test, start_time)

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -63,7 +63,7 @@ module AutoHCK
       extend T::Sig
       extend JsonHelper
 
-      const :desc, String
+      prop :desc, String
       const :timeout, T.nilable(Integer)
       const :capture_output, T.nilable(String)
       const :ignore_errors, T.nilable(T::Boolean)


### PR DESCRIPTION
We still have one test, but in the results, all steps are duplicated several times:
```
  "steps": [
    {
      "index": 0,
      "description": "[Cycle 1] [Step 1] Verify Balloon PnP device is present and working",
      "status": "passed",
      "start_time": "2026-07-25T11:27:03Z",
      "end_time": "2026-07-25T11:27:06Z",
      "duration": 3.12302699
    },
    {
      "index": 1,
      "description": "[Cycle 1] [Step 2] Install balloon service (blnsvr.exe -i)",
      "status": "passed",
      "start_time": "2026-07-25T11:27:06Z",
      "end_time": "2026-07-25T11:27:10Z",
      "duration": 3.293920649
    },
 ```


This behaviour is similar to HLK DV tests. HLK shows one test run, but the DV test itself runs several times. Logs contain each run