### PR TITLE
Functest: Add VM snapshot support for test cases

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -226,6 +226,25 @@ A test case defines an ordered sequence of steps and optional cleanup steps. Cas
 | `test_steps` | Yes | Ordered array of step objects; a failure aborts remaining steps |
 | `cleanup` | No | Steps run after test completes (pass or fail); errors here do not change test status |
 | `clients` | No | Client ids (e.g. `[1, 2]`) this test case needs booted. Default: `[1]`. See [Multi-Client Support](#multi-client-support). |
+| `clean_boot` | No | If `true`, throw away the client's current VM state and boot fresh from the clean base image before running `test_steps`. Can't be used together with `boot_from_snapshot_tag`. Default: `false`. |
+| `boot_from_snapshot_tag` | No | Name of a snapshot tag saved earlier in the suite by another test's `save_snapshot_as`. Boots from that tag before running `test_steps`. Can't be used together with `clean_boot`. |
+| `save_snapshot_as` | No | After `test_steps` pass, save the VM's disk as a snapshot tag with this name, then reboot from it. Other tests can later boot from this tag using `boot_from_snapshot_tag`. |
+
+### VM Snapshots
+
+`clean_boot`, `boot_from_snapshot_tag`, and `save_snapshot_as` let tests in a suite share VM state, so a later test can reuse what an earlier one set up instead of doing it again:
+
+| Order | Test | Field | Effect |
+|---|---|---|---|
+| 1 | `test_a` | `save_snapshot_as: "state_x"` | Runs as normal; if it passes, saves the VM's disk as tag `state_x`. |
+| 2 | `test_b` | `boot_from_snapshot_tag: "state_x"` | Boots from tag `state_x` instead of continuing from `test_a`. |
+| 3 | `test_c` | `boot_from_snapshot_tag: "state_x"` | Also boots from `state_x`, separately from `test_b`. |
+| 4 | `test_d` | `clean_boot: true` | Ignores all tags; boots from the clean base image. |
+| 5 | `test_e` | *(none)* | No change; just keeps using the VM as `test_d` left it. |
+
+A tag has to be created by an earlier test's `save_snapshot_as` before another test can use it with `boot_from_snapshot_tag`. Using a tag that doesn't exist yet fails the test with an error.
+
+Tag files (`*-snapshot-<tag>.qcow2` in the workspace directory) are never deleted automatically, whether the suite passes or fails. You can always boot from one later by hand to check the state it holds.
 
 ### Example
 

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -22,6 +22,15 @@ module AutoHCK
       # the platform JSON's clients map.
       const :clients, T::Array[Integer], default: [1]
 
+      # Which VM state to start this test from. Leave both unset to keep
+      # using whatever VM is already running. Can't set both at once.
+      const :clean_boot, T::Boolean, default: false
+      const :boot_from_snapshot_tag, T.nilable(String)
+
+      # After the test passes, save the VM's disk as a snapshot that other
+      # tests can start from via boot_from_snapshot_tag.
+      const :save_snapshot_as, T.nilable(String)
+
       sig { returns(String) }
       def safe_name
         name.gsub(/[^\w\-.]/, '_').gsub(/(^_|_$)/, '')

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -28,6 +28,7 @@ module AutoHCK
                                         default_timeout: engine.default_timeout)
         @results = []
         @current_test = nil
+        @created_tags = Set.new
       end
       # rubocop:enable Metrics/AbcSize
 
@@ -77,6 +78,8 @@ module AutoHCK
           'currentcount' => passed + failed + 1, 'total' => total }
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # There is no way to reduce the ABC size of this method without losing clarity.
       def create_local_test_copy(test)
         TestCase.new(
           name: test.name,
@@ -87,12 +90,16 @@ module AutoHCK
           cycles: test.cycles,
           test_steps: test.test_steps.map(&:dup),
           cleanup: test.cleanup.map(&:dup),
-          clients: test.clients.dup
+          clients: test.clients.dup,
+          clean_boot: test.clean_boot,
+          boot_from_snapshot_tag: test.boot_from_snapshot_tag,
+          save_snapshot_as: test.save_snapshot_as
         ).tap do |test_local|
           test_local.add_auto_index
           test_local.apply_cycles_to_steps
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def record_test(test)
         start_time = Time.now
@@ -142,9 +149,11 @@ module AutoHCK
 
       def run_test_steps(test, result)
         prepare_test_clients!(test)
+        ensure_boot_state!(test)
         run_extension_pre_test_commands(test.name)
         run_pre_test_commands(test)
-        test.test_steps.each_with_index { |step, index| result[:steps] << execute_test_step(step, index) }
+        execute_test_steps(test, result)
+        save_snapshot_if_needed(test)
         result[:status] = 'passed'
         @logger.info("PASSED: #{test.name}")
       rescue StandardError => e
@@ -172,6 +181,46 @@ module AutoHCK
           raise EngineError, "Test '#{test.name}' step targets client(s) #{unknown.join(', ')} not declared " \
                              "in this test case's own clients list (#{test.clients.join(', ')})"
         end
+      end
+
+      def execute_test_steps(test, result)
+        test.test_steps.each_with_index { |step, index| result[:steps] << execute_test_step(step, index) }
+      end
+
+      # Boots the VM into the state this test needs, if any. With neither
+      # field set, nothing happens and the VM stays as-is.
+      def ensure_boot_state!(test)
+        if test.clean_boot && test.boot_from_snapshot_tag
+          raise EngineError, "#{test.name}: clean_boot and boot_from_snapshot_tag are mutually exclusive"
+        end
+
+        client = @clients.first
+        if test.clean_boot
+          client.reboot_clean
+        elsif test.boot_from_snapshot_tag
+          ensure_tag_known!(test.boot_from_snapshot_tag, test.name)
+          client.reboot_from_snapshot(test.boot_from_snapshot_tag)
+        end
+      end
+
+      # A tag can only be used once the test that saved it (save_snapshot_as) has run.
+      def ensure_tag_known!(tag, test_name)
+        return if @created_tags.include?(tag)
+
+        raise EngineError, "#{test_name}: boot_from_snapshot_tag references unknown tag '#{tag}' " \
+                           '(the test that creates it via save_snapshot_as must run earlier in the suite)'
+      end
+
+      def save_snapshot_if_needed(test)
+        tag = test.save_snapshot_as
+        return unless tag
+
+        if @created_tags.include?(tag)
+          raise EngineError, "#{test.name}: snapshot tag '#{tag}' was already created by an earlier test"
+        end
+
+        @clients.first.save_snapshot(tag)
+        @created_tags << tag
       end
 
       def execute_test_step(step, index)

--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -13,12 +13,37 @@ module AutoHCK
       @project = setup_manager.project
       @logger = @project.logger
       @setup_manager = setup_manager
+      @scope = scope
       @name = name
       @logger.info("Starting functest client #{name}")
       @runner = setup_manager.run_client(scope, name, run_opts)
       scope << self
       @replacement_map = @project.project_replacement_map.merge(setup_manager.client_replacement_map(name))
       @winrm_addr = lookup_winrm_addr
+    end
+
+    # Boots a fresh VM from the clean base image, discarding current state.
+    def reboot_clean
+      @logger.info("Rebooting client #{@name} from a clean image")
+      @runner = @setup_manager.power_cycle_client(@scope, @name, create_snapshot: true)
+      reconnect
+    end
+
+    # Boots a fresh VM from a previously saved snapshot tag.
+    def reboot_from_snapshot(tag)
+      @setup_manager.client_snapshot_tag(@name, tag)
+      @logger.info("Rebooting client #{@name} from snapshot tag '#{tag}'")
+      @runner = @setup_manager.power_cycle_client(@scope, @name, create_snapshot: true, boot_from_tag: tag)
+      reconnect
+    end
+
+    # Saves the VM's current state as a snapshot tag and reboots from it.
+    def save_snapshot(tag)
+      @logger.info("Saving client #{@name}'s current state as snapshot tag '#{tag}'")
+      @setup_manager.stop_client(@name)
+      @setup_manager.client_save_snapshot(@name, tag)
+      @runner = @setup_manager.power_cycle_client(@scope, @name, create_snapshot: true, boot_from_tag: tag)
+      reconnect
     end
 
     # tools is a FunctestTools instance shared by every client booted this
@@ -38,6 +63,10 @@ module AutoHCK
     end
 
     private
+
+    def reconnect
+      @tools.wait_for_client_online(@name)
+    end
 
     def lookup_winrm_addr
       client = @project.engine_platform.clients.values.find { |c| c.name == @name }

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -93,6 +93,8 @@ module AutoHCK
       Runner.new(@logger)
     end
 
+    def power_cycle_client(*); end
+
     def client_post_start_commands
       []
     end

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -169,6 +169,7 @@ module AutoHCK
       first_time: false,
       create_snapshot: true,
       boot_from_snapshot: false,
+      boot_from_tag: nil,
       attach_iso_list: [],
       dump_only: false,
       secure: false
@@ -845,6 +846,16 @@ module AutoHCK
 
     def delete_snapshot
       @sm.delete_boot_snapshot
+    end
+
+    def snapshot_path(tag)
+      @sm.tag_snapshot_path(tag)
+    end
+
+    # Renames the current boot overlay to a named tag. The VM must already
+    # be stopped.
+    def save_snapshot(tag)
+      @sm.save_boot_snapshot_as_tag(tag)
     end
 
     def validate_run_opts(run_opts)

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -274,6 +274,28 @@ module AutoHCK
       @clients_vm_runners[name] = @clients_vm[name].run(scope, run_opts)
     end
 
+    # Stops the client's VM (if running) and boots a new one with run_opts.
+    def power_cycle_client(scope, name, run_opts = nil)
+      stop_client(name)
+      @clients_vm_runners[name] = @clients_vm[name].run(scope, run_opts)
+    end
+
+    # Stops the client's VM without deleting its disk, so the disk can
+    # still be read or saved as a snapshot afterwards.
+    def stop_client(name)
+      @clients_vm_runners[name]&.vm_abort
+    end
+
+    def client_save_snapshot(name, tag)
+      @clients_vm[name].save_snapshot(tag)
+    end
+
+    # Raises an error if the snapshot tag does not exist for the given client.
+    def client_snapshot_tag(name, tag)
+      path = @clients_vm[name].snapshot_path(tag)
+      raise AutoHCKError, "Unknown snapshot tag '#{tag}' for client #{name}" unless File.exist?(path)
+    end
+
     def run_hck_studio(scope, run_opts)
       HCKStudio.new(self, scope, run_opts) { @studio_vm.find_world_ip }
     end

--- a/lib/setupmanagers/qemuhck/storage_manager.rb
+++ b/lib/setupmanagers/qemuhck/storage_manager.rb
@@ -48,6 +48,12 @@ module AutoHCK
         "#{@workspace_path}/#{filename}-snapshot.#{IMAGE_FORMAT}"
       end
 
+      # Returns the workspace path for a named snapshot tag.
+      def tag_snapshot_path(tag)
+        filename = File.basename(@boot_image_path, '.*')
+        "#{@workspace_path}/#{filename}-snapshot-#{tag}.#{IMAGE_FORMAT}"
+      end
+
       def check_image_exist
         File.exist?(@boot_image_path)
       end
@@ -76,18 +82,33 @@ module AutoHCK
         end
       end
 
+      # Creates a new qcow2 overlay at target_path backed by backing_path.
+      def create_snapshot_from(backing_path, target_path)
+        run_cmd(*%W[#{@qemu_img_bin} create -f #{IMAGE_FORMAT} -F #{IMAGE_FORMAT}
+                    -b #{backing_path} #{target_path}])
+      end
+
       def create_boot_snapshot
         @logger.info("Creating CL#{@client_id} snapshot file")
-        run_cmd(*%W[#{@qemu_img_bin} create -f #{IMAGE_FORMAT} -F #{IMAGE_FORMAT}
-                    -b #{@boot_image_path} #{boot_snapshot_path}])
+        create_snapshot_from(@boot_image_path, boot_snapshot_path)
       end
 
       def delete_boot_snapshot
         FileUtils.rm_f(boot_snapshot_path)
       end
 
+      # Renames the current boot overlay to a named tag.
+      def save_boot_snapshot_as_tag(tag)
+        target = tag_snapshot_path(tag)
+        raise MachineRunError, "Snapshot tag already exists: '#{tag}' (#{target})" if File.exist?(target)
+
+        @logger.info("Saving CL#{@client_id} boot snapshot as tag '#{tag}'")
+        FileUtils.mv(boot_snapshot_path, target)
+        target
+      end
+
       def boot_device_command(device, run_opts, bus_name, qemu_replacement_map)
-        create_boot_snapshot if run_opts[:create_snapshot]
+        ensure_boot_image_ready(run_opts)
         image_path = boot_device_image_path(run_opts)
 
         options = {
@@ -99,8 +120,19 @@ module AutoHCK
         [device_command_info('boot', device, options, bus_name, qemu_replacement_map), image_path]
       end
 
+      # Creates the boot overlay, using the named snapshot tag as backing if set.
+      def ensure_boot_image_ready(run_opts)
+        if (tag = run_opts[:boot_from_tag])
+          create_snapshot_from(tag_snapshot_path(tag), boot_snapshot_path)
+          return
+        end
+
+        create_boot_snapshot if run_opts[:create_snapshot]
+      end
+
       def boot_device_image_path(run_opts)
-        return boot_snapshot_path if run_opts[:create_snapshot] || run_opts[:boot_from_snapshot]
+        return boot_snapshot_path if run_opts[:boot_from_tag] || run_opts[:create_snapshot] ||
+                                     run_opts[:boot_from_snapshot]
 
         @boot_image_path
       end


### PR DESCRIPTION
Adds `clean_boot`, `boot_from_snapshot_tag`, and `save_snapshot_as` to
Functest test cases, so a suite can share VM state across tests
instead of every test continuing from wherever the last one left the
VM.

- `clean_boot`: boot from a clean base image
- `boot_from_snapshot_tag`: boot from a tag saved by an earlier test
- `save_snapshot_as`: save the VM's state after a test passes, as a
  tag other tests can boot from later