### PR TITLE
Functest: coerce numeric QMP args after placeholder substitution

### DIFF
--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -191,6 +191,22 @@ module AutoHCK
       result
     end
 
+    # QEMU QMP expects JSON numbers for numeric device properties (e.g. guest-cid
+    # as uint64). ReplacementMap#replace always yields Strings, so coerce
+    # digit-only values after substitution. Non-numeric strings are unchanged.
+    def coerce_numeric_qmp_values(value)
+      case value
+      when String
+        value.match?(/\A-?\d+\z/) ? value.to_i : value
+      when Hash
+        value.transform_values { |v| coerce_numeric_qmp_values(v) }
+      when Array
+        value.map { |v| coerce_numeric_qmp_values(v) }
+      else
+        value
+      end
+    end
+
     sig { params(command_info: Models::CommandInfo, replacement: ReplacementMap).returns(T.untyped) }
     def execute_qmp_command(command_info, replacement)
       qmp = T.must(command_info.qmp_command)
@@ -199,7 +215,7 @@ module AutoHCK
       outputs = {}
       @machines.each do |machine_name|
         map = replacement_map_for(machine_name, replacement, command_info)
-        arguments = qmp.arguments && map.replace(qmp.arguments)
+        arguments = qmp.arguments && coerce_numeric_qmp_values(map.replace(qmp.arguments))
         outputs[machine_name] = run_qmp_command(execute, arguments, machine_name)
       rescue QMPError => e
         raise EngineError, "QMP command '#{execute}' failed on #{machine_name}: #{e.message}"


### PR DESCRIPTION
## Summary
- After `@variable@` substitution, Functest `qmp_command` arguments remain JSON strings.
- QEMU rejects string values for numeric properties such as `guest-cid` (`uint64`).
- Coerce digit-only substituted QMP argument values to `Integer` in `CommandExecutionManager` (non-numeric strings unchanged).

## Why
Blocks viosock (and similar) hotplug functests that use dynamic CID templates like `"1@client_id@0@run_id@"`. Cannot be fixed in test JSON alone without hardcoding.

Related epic: VIRTWINKVM-2178

## Test plan
- [x] Applied patch on AutoHCK-latest and ran:
  ```bash
  ./bin/auto_hck --id 57 functest -p Win2025x64_gui -d viosock \
    --driver-path <viosock/2k25/amd64> \
    --pcie-spare-root-ports 1 \
    --testcase viosock/viosock_hotplug
  ```
- [x] Result: **PASSED** (Step 5 `device_add` now succeeds; previously failed with `guest-cid expects uint64`)
