### PR TITLE
QMP: support waiting for multiple alternative events

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -329,14 +329,24 @@ Send a QEMU Monitor Protocol (QMP) command to the client VM at the hypervisor le
 
 ### `qmp_wait_event`
 
-Blocks until a specific QEMU event is received from the client VM.
+Blocks until one of the given QEMU events is received from the client VM. `events` is a list of event names; this returns as soon as any one of them is seen — useful for devices that may emit one of several events depending on guest state:
 
 ```json
 {
     "desc": "Wait for balloon change event",
     "qmp_wait_event": {
-        "event": "BALLOON_CHANGE",
+        "events": ["BALLOON_CHANGE"],
         "timeout": 30
+    }
+}
+```
+
+```json
+{
+    "desc": "Wait for a guest crash event from the pvpanic device",
+    "qmp_wait_event": {
+        "events": ["GUEST_PANICKED", "GUEST_CRASHLOADED"],
+        "timeout": 120
     }
 }
 ```
@@ -345,8 +355,10 @@ Blocks until a specific QEMU event is received from the client VM.
 
 | Field | Required | Description |
 |---|---|---|
-| `event` | Yes | QMP event name to wait for (e.g. `BALLOON_CHANGE`) |
+| `events` | Yes | Array of QMP event names to wait for (e.g. `["BALLOON_CHANGE"]`); returns as soon as any one occurs |
 | `timeout` | No | Maximum seconds to wait. Defaults to the engine `default_timeout`. |
+
+> Use `capture_output` to record which event actually fired (the full event payload, including its `event` name, is captured) so a later step can branch on it.
 
 ---
 

--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -208,10 +208,11 @@ module AutoHCK
       outputs
     end
 
-    sig { params(event: String, machine_name: String, timeout: Integer).returns(T.untyped) }
-    def run_qmp_wait_event(event, machine_name, timeout)
-      @logger.info("Waiting for QMP event '#{event}' on #{machine_name} (timeout: #{timeout}s)")
-      response = @project.setup_manager.wait_for_hypervisor_client_event(machine_name, event, timeout: timeout)
+    sig { params(events: T::Array[String], machine_name: String, timeout: Integer).returns(T.untyped) }
+    def run_qmp_wait_event(events, machine_name, timeout)
+      events_desc = events.join("' or '")
+      @logger.info("Waiting for QMP event '#{events_desc}' on #{machine_name} (timeout: #{timeout}s)")
+      response = @project.setup_manager.wait_for_hypervisor_client_event(machine_name, events, timeout: timeout)
       @logger.debug("QMP event received: #{response.inspect}")
 
       response
@@ -221,13 +222,14 @@ module AutoHCK
     def execute_qmp_wait_event(command_info)
       qmp = T.must(command_info.qmp_wait_event)
       timeout = qmp.timeout || command_info.timeout || @default_timeout
-      event = qmp.event
+      events = qmp.events
+      events_desc = events.join("' or '")
 
       outputs = {}
       @machines.each do |machine_name|
-        outputs[machine_name] = run_qmp_wait_event(event, machine_name, timeout)
+        outputs[machine_name] = run_qmp_wait_event(events, machine_name, timeout)
       rescue QMPError => e
-        raise EngineError, "QMP event '#{event}' wait failed on #{machine_name}: #{e.message}"
+        raise EngineError, "QMP event '#{events_desc}' wait failed on #{machine_name}: #{e.message}"
       end
 
       outputs

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -53,7 +53,9 @@ module AutoHCK
     class QmpWaitEventConfig < T::Struct
       extend T::Sig
 
-      const :event, String
+      # List of event names to wait for; returns as soon as any one of
+      # them occurs (e.g. a device that may emit either one).
+      const :events, T::Array[String]
       const :timeout, T.nilable(Integer)
     end
 

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -266,8 +266,8 @@ module AutoHCK
       @clients_vm_runners[name].qmp.run_cmd(cmd, arguments)
     end
 
-    def wait_for_hypervisor_client_event(name, event, timeout: 60)
-      @clients_vm_runners[name].qmp.wait_for('event', event, timeout)
+    def wait_for_hypervisor_client_event(name, events, timeout: 60)
+      @clients_vm_runners[name].qmp.wait_for('event', events, timeout)
     end
 
     def run_client(scope, name, run_opts = nil)

--- a/lib/setupmanagers/qemuhck/qmp.rb
+++ b/lib/setupmanagers/qemuhck/qmp.rb
@@ -38,24 +38,34 @@ module AutoHCK
         send_cmd(cmd, arguments)
       end
 
-      def wait_for(name, value, timeout = 60)
-        if (index = @events.index { |e| e[name] == value })
-          return @events.delete_at(index)
-        end
+      # accepted is an array of acceptable values; this returns as soon as
+      # any one of them is seen.
+      def wait_for(name, accepted, timeout = 60)
+        cached = find_cached_event(name, accepted)
+        return cached if cached
 
+        wait_for_new_event(name, accepted, timeout)
+      end
+
+      private
+
+      def find_cached_event(name, accepted)
+        index = @events.index { |e| accepted.include?(e[name]) }
+        @events.delete_at(index) if index
+      end
+
+      def wait_for_new_event(name, accepted, timeout)
         Timeout.timeout(timeout) do
           loop do
             response = JSON.parse(@socket_internal.readline)
             @logger.debug("Received QMP message: #{response}")
-            return response if response[name] == value
+            return response if accepted.include?(response[name])
 
             @events << response if response.key?('event')
             raise(QMPError, response['error'].to_s) if response.key?('error')
           end
         end
       end
-
-      private
 
       def send_cmd(cmd, arguments = nil)
         cmd_hash = { 'execute' => cmd }


### PR DESCRIPTION
qmp_wait_event's event field now also accepts an array of names, returning as soon as any one of them is seen (e.g. pvpanic may emit either GUEST_PANICKED or GUEST_CRASHLOADED).