### PR TITLE
Add --client-world-net-dev to select world NIC model

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -48,6 +48,10 @@ Usage: auto_hck.rb [common options] <command> [command options]
         --client_world_net           Attach world bridge to clients VM
         --client-ctrl-net-dev <client-ctrl-net-dev>
                                      Client VM control network device (make sure that driver is installed)
+        --client-world-net-dev <client-world-net-dev>
+                                     Client VM world network device (default: e1000e; make sure that driver is
+                                     installed). Ignored unless --client_world_net. Example: virtio-net-pci
+                                     (NetKVM world/L3)
         --attach-debug-net           Attach debug network to all VMs
         --id <id>                    Set ID for AutoHCK run
     -v, --version                    Display version information and exit

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -12,6 +12,7 @@ module AutoHCK
     prop :share_on_host_path, T.nilable(String)
     prop :workspace_path, T.nilable(String)
     prop :client_ctrl_net_dev, T.nilable(String)
+    prop :client_world_net_dev, T.nilable(String)
     prop :attach_debug_net, T::Boolean, default: false
     prop :whiteboard, T.nilable(String)
 
@@ -51,6 +52,11 @@ module AutoHCK
       parser.on('--client-ctrl-net-dev <client-ctrl-net-dev>', String,
                 'Client VM control network device (make sure that driver is installed)',
                 &method(:client_ctrl_net_dev=))
+
+      parser.on('--client-world-net-dev <client-world-net-dev>', String,
+                'Client VM world network device (default: e1000e; make sure that driver is installed).',
+                'Ignored unless --client_world_net. Example: virtio-net-pci (NetKVM world/L3)',
+                &method(:client_world_net_dev=))
 
       parser.on('--attach-debug-net', TrueClass,
                 'Attach debug network to all VMs',

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -113,7 +113,8 @@ module AutoHCK
         'discard_granularity' => test_opt.discard_granularity,
         'fs_daemon_cache_mode' => test_opt.fs_daemon_cache_mode,
         'pcie_spare_root_ports' => test_opt.pcie_spare_root_ports,
-        'ctrl_net_device' => common.client_ctrl_net_dev
+        'ctrl_net_device' => common.client_ctrl_net_dev,
+        'world_net_device' => common.client_world_net_dev
       }.compact
     end
     # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
## Summary
- Add `--client-world-net-dev` mirroring existing `--client-ctrl-net-dev`.
- Maps to `world_net_device` so `--client_world_net` can attach `virtio-net-pci` (or another device) instead of the default **e1000e**.
- Default unchanged when the flag is omitted (`.compact` + `platforms_defaults`).

## Why
`--client_world_net` attaches the world bridge, but the device model was not selectable. Callers that need L3 on VirtIO (e.g. NetKVM guest tests) otherwise get an Intel NIC and can falsely attribute connectivity to the wrong driver.

## Usage
```bash
./bin/auto_hck --client_world_net --client-world-net-dev virtio-net-pci <command> ...
```

## Test plan
- [x] `./bin/auto_hck --help` shows the new option
- [x] With `--client_world_net --client-world-net-dev virtio-net-pci`, QEMU world device is `virtio-net-pci` (MAC `...:dd:dd`), not `e1000e`
- [x] NetKVM guest ping via VirtIO world: `netkvm_ping_default` + `netkvm_ping_ext_host` **2/2 PASS**
- [x] Without the new flag, world device remains default `e1000e`
