### PR TITLE
Functest: Add extension support and Driver verifier extension

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -22,6 +22,7 @@ The functest engine runs JSON-driven functional tests against a Windows client V
 | `--reject-test-names <file>` | Path to a text file (one test name per line); tests whose name appears in the file are skipped. Overrides the suite's own `reject_test_names`, if any. |
 | `--manual` | Run tests normally, then pause before VM teardown and drop into an IRB shell for manual inspection |
 | `--auto-manual` | Same as `--manual`, but only pauses if any test failed or an exception occurred |
+| `--extensions <list>` | Comma-separated list of extension names to activate (e.g. `driver_verifier`); each maps to `lib/engines/hcktest/extensions/<name>.json` |
 
 Exactly one of `--category` or `--testcase` is required. All common options (`--verbose`, `--config`, `--id`, etc.) apply as documented in [Home](Home.md).
 
@@ -127,6 +128,49 @@ lib/engines/functest/
 | `test_definitions_path` | Root directory for test case and suite JSON files |
 | `default_timeout` | Default step timeout in seconds (used when a step does not specify `timeout`) |
 | `result_format` | Output formats for results (e.g. `["json", "junit"]`) |
+
+## Extensions
+
+Extensions inject commands around test cases without modifying test case JSON files. They are stored in `lib/engines/hcktest/extensions/` and activated via `--extensions <name>` (comma-separated for multiple).
+
+Execution order per test:
+
+```
+extension pre_test_commands   (e.g. enable DV + reboot)
+  test pre_test_commands
+    test_steps
+  test cleanup
+extension post_test_commands  (e.g. disable DV + reboot)
+```
+
+A failure in extension `pre_test_commands` marks the test failed. A failure in `post_test_commands` is logged as a warning only.
+
+### Extension JSON format
+
+| Field | Description |
+|---|---|
+| `extra_software` | Packages to pre-install on the guest before any tests run |
+| `tests_config` | Array of per-test hook entries |
+
+Each `tests_config` entry:
+
+| Field | Description |
+|---|---|
+| `tests` | Regex patterns matched against the test case `name` field. Use `[".*"]` for all tests. |
+| `pre_test_commands` | Steps run before each matching test |
+| `post_test_commands` | Steps run after each matching test |
+
+> `tests` matches the `name` field inside the test case JSON, **not** the path used in a suite. A test at `balloon/balloon_service` has `name` = `balloon_service`.
+
+Multiple extensions can be listed with `--extensions EXT1,EXT2`. The order follows the CLI argument order — EXT1 pre commands run before EXT2 pre commands, and the same for post commands.
+
+### Available extensions
+
+| Name | Description |
+|---|---|
+| `driver_verifier` | Enables Driver Verifier (standard flags) before each test and disables it after, with a reboot on each side. |
+
+---
 
 ## Test Suite Format
 

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -13,8 +13,13 @@ module AutoHCK
     include Helper
 
     DRIVERS_JSON_DIR = 'lib/engines/hcktest/drivers'
+    EXTENSIONS_JSON_DIR = 'lib/engines/hcktest/extensions'
 
-    attr_reader :project, :logger, :drivers
+    attr_reader :project, :logger, :drivers, :extensions
+
+    def default_timeout
+      @config['default_timeout']
+    end
 
     def initialize(project)
       @project = project
@@ -23,6 +28,7 @@ module AutoHCK
       @config = load_engine_config
       @drivers = load_drivers
       @tests = init_tests
+      @extensions = find_extensions
       prepare_extra_sw
       @logger.info('Functest engine initialized')
     end
@@ -94,8 +100,12 @@ module AutoHCK
         prepare_clients(clients, tools)
         command_execution_manager = build_command_execution_manager(tools, clients)
 
-        @executor = Functest::TestExecutor.new(@project, clients, tools, command_execution_manager,
-                                               default_timeout: @config['default_timeout'])
+        run_context = Functest::TestExecutor::RunContext.new(
+          clients: clients,
+          tools: tools,
+          command_execution_manager: command_execution_manager
+        )
+        @executor = Functest::TestExecutor.new(self, run_context)
         setup_test_context(@executor.context)
         summary = @executor.execute_tests(@tests)
 
@@ -262,6 +272,7 @@ module AutoHCK
 
     def prepare_extra_sw
       extra_softwares = @drivers.flat_map(&:extra_software)
+      extra_softwares += @extensions.flat_map(&:extra_software)
       extra_softwares += @project.engine_platform.extra_software
       extra_softwares += @suite.requirements.extra_software if @suite
       extra_softwares += @tests.flat_map(&:extra_software)
@@ -310,6 +321,14 @@ module AutoHCK
       context.set_variable('driver_module', module_name)
 
       @logger.info("Test context: driver_module=#{module_name}, driver_inf=#{drv.inf}")
+    end
+
+    def find_extensions
+      @project.options.test.extensions.map do |ext_name|
+        @logger.info("Loading functest extension: #{ext_name}")
+        path = File.join(EXTENSIONS_JSON_DIR, "#{File.basename(ext_name)}.json")
+        Models::Extension.from_json_file(path, @logger)
+      end
     end
 
     def load_engine_config

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -12,21 +12,24 @@ module AutoHCK
         @results.map { |r| Models::TestResult.from_functest(r) }
       end
 
-      # clients is every FunctestClient booted for this run. tools and
-      # command_execution_manager are shared by all of them.
-      def initialize(project, clients, tools, command_execution_manager, default_timeout:)
-        @project = project
-        @clients = clients
-        @tools = tools
-        @machine_names = clients.map(&:name)
-        @logger = project.logger
-        @context = TestContext.new(project, clients.first.replacement_map)
-        @command_execution_manager = command_execution_manager
-        @step_handler = StepHandler.new(project, @command_execution_manager, @context,
-                                        default_timeout: default_timeout)
+      RunContext = Struct.new(:clients, :tools, :command_execution_manager, keyword_init: true)
+
+      # rubocop:disable Metrics/AbcSize
+      def initialize(engine, run_context)
+        @project = engine.project
+        @extensions = engine.extensions
+        @clients = run_context.clients
+        @tools = run_context.tools
+        @machine_names = run_context.clients.map(&:name)
+        @logger = engine.project.logger
+        @context = TestContext.new(engine.project, run_context.clients.first.replacement_map)
+        @command_execution_manager = run_context.command_execution_manager
+        @step_handler = StepHandler.new(@project, @command_execution_manager, @context,
+                                        default_timeout: engine.default_timeout)
         @results = []
         @current_test = nil
       end
+      # rubocop:enable Metrics/AbcSize
 
       def execute_test(test)
         log_section("Starting test: #{test.name}")
@@ -112,6 +115,13 @@ module AutoHCK
 
       def finalize_result(result, test, start_time)
         run_cleanup(test)
+        begin
+          run_extension_post_test_commands(test.name)
+        rescue StandardError => e
+          @logger.error("Extension post-test command failed: #{e.message}")
+          result[:status] = 'failed'
+          result[:error] = e.message
+        end
         result[:dump_path] = collect_memory_dumps(test.name)
         end_time = Time.now
         result[:end_time] = end_time.utc.iso8601
@@ -132,6 +142,7 @@ module AutoHCK
 
       def run_test_steps(test, result)
         prepare_test_clients!(test)
+        run_extension_pre_test_commands(test.name)
         run_pre_test_commands(test)
         test.test_steps.each_with_index { |step, index| result[:steps] << execute_test_step(step, index) }
         result[:status] = 'passed'
@@ -220,6 +231,42 @@ module AutoHCK
       def collect_memory_dumps(test_name)
         id = test_name.gsub(/\W/, '_')
         MemoryDumpCollector.new(@tools, @machine_names, @project.workspace_path, @logger).collect(id)
+      end
+
+      def extension_commands_for(test_name, type)
+        @extension_test_regexes ||= {}
+        @extensions.flat_map(&:tests_config).select do |config|
+          regex = (@extension_test_regexes[config] ||= Regexp.union(config.tests.map { Regexp.new(_1) }))
+          regex.match?(test_name)
+        end.flat_map(&type)
+      end
+
+      def run_extension_pre_test_commands(test_name)
+        cmds = extension_commands_for(test_name, :pre_test_commands)
+        return if cmds.empty?
+
+        @logger.info('Running extension pre-test commands...')
+        cmds.each_with_index do |step, index|
+          desc = @context.substitute_variables("[Extension pre-test step #{index + 1}] #{step.desc}")
+          @step_handler.execute_step(step, index)
+        rescue StandardError => e
+          @logger.error("  FAIL: Extension pre-test command failed (#{desc}): #{e.message}")
+          raise
+        end
+      end
+
+      def run_extension_post_test_commands(test_name)
+        cmds = extension_commands_for(test_name, :post_test_commands)
+        return if cmds.empty?
+
+        @logger.info('Running extension post-test commands...')
+        cmds.each_with_index do |step, index|
+          desc = @context.substitute_variables("[Extension post-test step #{index + 1}] #{step.desc}")
+          @step_handler.execute_step(step, index)
+        rescue StandardError => e
+          @logger.error("  FAIL: Extension post-test command failed (#{desc}): #{e.message}")
+          raise
+        end
       end
     end
   end

--- a/lib/engines/functest/tests/scripts/disable_driver_verifier.ps1
+++ b/lib/engines/functest/tests/scripts/disable_driver_verifier.ps1
@@ -1,0 +1,14 @@
+# Disable Driver Verifier and confirm it is no longer set for @driver_module@.sys.
+# Outputs PASS: on success; throws on failure.
+
+$ErrorActionPreference = "Continue"
+$driver = "@driver_module@"
+
+cmd /c "verifier /reset 2>&1"
+
+$status = cmd /c "verifier /querysettings 2>&1" | Out-String
+if ($status -match [regex]::Escape($driver)) {
+    throw "Driver Verifier still set for $driver after disable"
+}
+
+Write-Output "PASS: Driver Verifier disabled for $driver.sys"

--- a/lib/engines/functest/tests/scripts/enable_driver_verifier.ps1
+++ b/lib/engines/functest/tests/scripts/enable_driver_verifier.ps1
@@ -1,0 +1,14 @@
+# Enable Driver Verifier (standard flags) for @driver_module@.sys.
+# Outputs PASS: on success; throws on failure.
+
+$ErrorActionPreference = "Continue"
+$driver = "@driver_module@"
+
+cmd /c "verifier /standard /driver $driver.sys 2>&1"
+
+$status = cmd /c "verifier /querysettings 2>&1" | Out-String
+if ($status -notmatch [regex]::Escape($driver)) {
+    throw "Driver Verifier not set for $driver after enable"
+}
+
+Write-Output "PASS: Driver Verifier enabled on $driver.sys"

--- a/lib/engines/hcktest/extensions/driver_verifier.json
+++ b/lib/engines/hcktest/extensions/driver_verifier.json
@@ -1,0 +1,31 @@
+{
+  "tests_config": [
+    {
+      "tests": [".*"],
+      "pre_test_commands": [
+        {
+          "desc": "Enable Driver Verifier for @driver_module@",
+          "guest_run_file": "lib/engines/functest/tests/scripts/enable_driver_verifier.ps1",
+          "expected_output_contains": "PASS:",
+          "timeout": 60
+        },
+        {
+          "desc": "Reboot to activate Driver Verifier settings",
+          "guest_reboot": true
+        }
+      ],
+      "post_test_commands": [
+        {
+          "desc": "Disable Driver Verifier for @driver_module@",
+          "guest_run_file": "lib/engines/functest/tests/scripts/disable_driver_verifier.ps1",
+          "expected_output_contains": "PASS:",
+          "timeout": 60
+        },
+        {
+          "desc": "Reboot to deactivate Driver Verifier settings",
+          "guest_reboot": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add an extension mechanism to the functest engine. 
Extensions are JSON files under
`lib/engines/functest/extensions/` and activated via `--extensions`.

Each extension declares `tests_config` entries with `pre_test_commands`
and `post_test_commands` that wrap around matching test cases, and
optional `extra_software` packages to pre-install on the guest.

Add `driver_verifier` as the first extension
Example:
`bin/auto_hck --verbose functest -p Win2025x64_gui --category balloon_driver_tests -d Balloon --driver-path /tmp/virtio-win/Balloon/2k25/amd64 --extensions driver_verifier`