### PR TITLE
[Setupmanager] Create support for two NUMA node guest deployment

### DIFF
--- a/lib/engines/hcktest/drivers/viomem.json
+++ b/lib/engines/hcktest/drivers/viomem.json
@@ -4,5 +4,6 @@
   "inf": "viomem.inf",
   "install_method": "PNP",
   "type": 0,
-  "support": false
+  "support": false,
+  "numa_state": true
 }

--- a/lib/models/driver.rb
+++ b/lib/models/driver.rb
@@ -25,6 +25,8 @@ module AutoHCK
       const :s3_state, T.nilable(T::Boolean)
       const :s4_state, T.nilable(T::Boolean)
       const :enlightenments_state, T.nilable(T::Boolean)
+      const :numa_state, T.nilable(T::Boolean)
+      const :pcie_spare_root_ports, T.nilable(Integer)
 
       const :post_start_commands, T::Array[CommandInfo], default: []
       const :extra_software, T::Array[String], default: []

--- a/lib/setupmanagers/qemuhck/devices/numa-topology.json
+++ b/lib/setupmanagers/qemuhck/devices/numa-topology.json
@@ -1,0 +1,9 @@
+{
+  "name": "numa-topology",
+  "command_line": [
+    "-object memory-backend-ram,id=numa_mem0,size=@numa_node0_memory@",
+    "-object memory-backend-ram,id=numa_mem1,size=@numa_node1_memory@",
+    "-numa node,memdev=numa_mem0,cpus=0-@numa_node0_max_cpu@",
+    "-numa node,memdev=numa_mem1,cpus=@numa_node1_min_cpu@-@numa_node1_max_cpu@"
+  ]
+}

--- a/lib/setupmanagers/qemuhck/devices/virtio-mem-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-mem-pci.json
@@ -1,9 +1,13 @@
 {
   "name": "virtio-mem-pci",
-  "pluggable_memory_gb": 2,
+  "pluggable_memory_gb": 8,
   "need_pci_bus": true,
   "command_line": [
-    "-object memory-backend-ram,id=mem_backend,size=@pluggable_memory@",
-    "-device virtio-mem-pci@device_extra_param@@iommu_device_param@,id=mem_@run_id@_@client_id@,memdev=mem_backend,requested-size=1G,bus=@bus_name@.0"
-  ]
+    "-object memory-backend-ram,id=mem_viomem_@run_id@_@client_id@,size=@viomem_boot_backend_size@",
+    "-device virtio-mem-pci@device_extra_param@@iommu_device_param@,id=mem_@run_id@_@client_id@,memdev=mem_viomem_@run_id@_@client_id@,node=@viomem_numa_node@,requested-size=1G,bus=@bus_name@.0"
+  ],
+  "define_variables": {
+    "@viomem_numa_node@": "0",
+    "@viomem_boot_backend_size@": "2G"
+  }
 }

--- a/lib/setupmanagers/qemuhck/qemu_machine.json
+++ b/lib/setupmanagers/qemuhck/qemu_machine.json
@@ -32,6 +32,7 @@
     "vhost_state": true,
     "viommu_state": false,
     "drive_unsafe_cache_state": false,
-    "tpm_state": false
+    "tpm_state": false,
+    "numa_state": false
   }
 }

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -436,6 +436,27 @@ module AutoHCK
       { '@fs_daemon_cache_mode@' => mode }
     end
 
+    def numa_replacement_map
+      return {} unless option_config('numa_state')
+
+      cpu_count = option_config('cpu_count').to_i
+      raise "NUMA topology requires at least 2 vCPUs (got #{cpu_count})" if cpu_count < 2
+
+      memory_gb = option_config('memory_gb')
+      raise "NUMA topology requires at least 2 GB memory (got #{memory_gb})" if memory_gb < 2
+
+      half_cpu = cpu_count / 2
+      half_mem = memory_gb / 2
+
+      {
+        '@numa_node0_memory@' => "#{half_mem}G",
+        '@numa_node1_memory@' => "#{memory_gb - half_mem}G",
+        '@numa_node0_max_cpu@' => (half_cpu - 1).to_s,
+        '@numa_node1_min_cpu@' => half_cpu.to_s,
+        '@numa_node1_max_cpu@' => (cpu_count - 1).to_s
+      }
+    end
+
     sig { returns(T::Array[String]) }
     def device_config_commands
       @device_infos.map(&:config_commands).flatten.compact
@@ -482,6 +503,7 @@ module AutoHCK
                                              discard_granularity_replacement_map,
                                              fs_daemon_cache_mode_replacement_map,
                                              device_define_variables,
+                                             numa_replacement_map,
                                              @define_variables)
     end
 
@@ -666,7 +688,7 @@ module AutoHCK
     def base_cmd
       [
         '@qemu_bin@ -enable-kvm -machine @machine_options@ ',
-        '-m @memory@,maxmem=@max_memory@ -smp @cpu_count@,cores=@cpu_count@ ',
+        '-m @memory@,maxmem=@max_memory@@memory_slots@ -smp @cpu_count@,cores=@cpu_count@ ',
         '-cpu @cpu_options@ -boot menu=on,splash-time=10000 ',
         '-nodefaults -no-user-config -usb -device usb-tablet -vnc :@vnc_id@ ',
         '-global kvm-pit.lost_tick_policy=discard -rtc base=localtime,clock=host,driftfix=slew ',

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -16,7 +16,7 @@ module AutoHCK
 
     QEMUHCK_INFO_LOG_FILE = 'qemuhck.txt'
     OPT_NAMES = %w[viommu_state s3_state s4_state enlightenments_state vhost_state machine_type fw_type cpu
-                   ctrl_net_device vbs_state tpm_state].freeze
+                   ctrl_net_device vbs_state tpm_state numa_state pcie_spare_root_ports].freeze
 
     def initialize(project)
       @platform = T.let(project.engine_platform, Models::HLKPlatform)

--- a/lib/setupmanagers/qemuhck/states.json
+++ b/lib/setupmanagers/qemuhck/states.json
@@ -66,6 +66,21 @@
             ]
         }
     },
+    "numa_state": {
+        "true": {
+            "devices_list": [
+                "numa-topology"
+            ],
+            "define_variables": {
+                "@memory_slots@": ",slots=20"
+            }
+        },
+        "false": {
+            "define_variables": {
+                "@memory_slots@": ""
+            }
+        }
+    },
     "vbs_state": {
         "true": {
             "post_start_commands": [


### PR DESCRIPTION
Part of testing `viomem` within tp-qemu were a set of tests that explicitly hotplugged virtio-mem-pci to a guest's second NUMA node.  Besides testing that grow/shrink operations are working it also monitors that the expected NUMA node under test reflects those changes accordingly and NUMA node 0 is not impacted.  HCK-CI currently deploys all guests with a single NUMA node so that testing approach is not possible.  This commit adds support to deploy a two NUMA node guest when requested.  If a driver json definition includes `numa_state: true` then the corresponding guest will deploy with the updated NUMA topology. Implemented the following changes:

File changes:

- `setupmanagers/qemuhck/devices/numa-topology.json`: Created a new device defining default NUMA topology and cmd line.
- `engines/hcktest/drivers/viomem.json`: Updated to with `numa_state: true` and `pcie_spare_root_ports: 1` to allocate an empty PCIe root port for virtio-mem hotplug.
- `models/driver.rb`: Added corresponding properties `numa_state` and `pcie_spare_root_ports`.
- `setupmanagers/qemuhck/devices/virtio-mem-pci.json`: To account for grow/shrink increased maxmem from 2 to 8 for `pluggable_memory_gb`.  Using the variable `pluggable_memory` resulted in the boot device consuming all memory defined by `pluggable_memory_gb` blocking any grow tests. Created a new variable `viomem_boot_backend_size` to maintain the original 2GB size for boot disk and leaving the remaining 6GB for grow operations. Lastly added `viomem_numa_node` to allocate the boot device to NUMA node 0.
- `setupmanagers/qemuhck/qemu_machine.json`: Define default numa state to false
- `setupmanagers/qemuhck/qemu_machine.rb`: If none default values from `numa-topology.json` are not used, dynamically come up with the correct cpu and memory allocation based on total cpu count and memory for the guest. The allocations are purely for a two NUMA node setup. Also update `base_cmd` to use memory slots in the event that NUMA is active.
- `setupmanagers/qemuhck/qemuhck.rb`: Update `OPT_NAMES` with new `numa_state` and `pcie_spare_root_ports` properties.
-  `setupmanagers/qemuhck/states.json`: Update `define_variables` based on `numa_state`.  If true device list now includes numa-toplogy and updates memory_slots to 20, if false define memory_slots to nothing.