### PR TITLE
Expose vm_memory_gb to functest scripts

### DIFF
--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -276,10 +276,18 @@ module AutoHCK
       context.set_variable('test_binaries_path', test_binaries_path) if test_binaries_path
 
       set_driver_context_variables(context, @drivers.first)
+      apply_platform_context_variables(context)
 
       @project.options.test.test_params.each do |key, value|
         context.set_variable(key, value)
       end
+    end
+
+    def apply_platform_context_variables(context)
+      client = @project.engine_platform.clients.values.first
+      return unless client&.memory_gb
+
+      context.set_variable('vm_memory_gb', client.memory_gb.to_s)
     end
 
     def set_driver_context_variables(context, drv)


### PR DESCRIPTION
One initial issue when analyzing preliminary KAR results was the lack of disk space available when creating guest dumps. Depending on the hypervisor's storage partition and associated avocado workspace there was a risk of tests failing due to the overall file size.  The failure reported by KAR was not very clear when we were debugging the environment and I think it would benefit to clarify this issue when migrating tests to HCK-CI. By exposing the guest's disk size to the functest scripts, tests can do pre-checks on the hypervisor to confirm there is enough available space based on the expected size of the guest e.g.:

```
WORKSPACE="@workspace@"
VM_MEM_GB=@vm_memory_gb@

REQUIRED_GB=$(( VM_MEM_GB * 25 / 10 + 1 ))
AVAIL_GB=$(df -BG "$(dirname "$WORKSPACE")" | awk 'NR==2 {print $4}' | sed 's/G//')

if [[ "$AVAIL_GB" -lt "$REQUIRED_GB" ]]; then
    echo "FAIL: insufficient disk space for dump." >&2
    echo "  VM memory: ${VM_MEM_GB}GB  Need: ${REQUIRED_GB}GB  Available: ${AVAIL_GB}GB" >&2
    exit 1
fi

echo "PASS: disk space OK (${AVAIL_GB}GB available, ${REQUIRED_GB}GB needed for ${VM_MEM_GB}GB VM)"
```
Adding a check like this would at least provide a clear explanation that the test would fail before attempting to proceed.