### PR TITLE
Functest: add --manual and --auto-manual mode support

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -20,6 +20,8 @@ The functest engine runs JSON-driven functional tests against a Windows client V
 | `--testcase <names>` | Comma-separated list of test case names to run (e.g. `driver_sign_check,balloon/balloon_service`) |
 | `--select-test-names <file>` | Path to a text file (one test name per line); only tests whose name appears in the file are kept |
 | `--reject-test-names <file>` | Path to a text file (one test name per line); tests whose name appears in the file are skipped. Overrides the suite's own `reject_test_names`, if any. |
+| `--manual` | Run tests normally, then pause before VM teardown and drop into an IRB shell for manual inspection |
+| `--auto-manual` | Same as `--manual`, but only pauses if any test failed or an exception occurred |
 
 Exactly one of `--category` or `--testcase` is required. All common options (`--verbose`, `--config`, `--id`, etc.) apply as documented in [Home](Home.md).
 

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -99,8 +99,12 @@ module AutoHCK
         setup_test_context(@executor.context)
         summary = @executor.execute_tests(@tests)
 
+        pause_run_if_needed(summary)
         generate_results(summary)
         summary[:failed].zero? ? 0 : 1
+      rescue StandardError => e
+        pause_run_if_needed(nil, e)
+        raise
       end
     rescue StandardError => e
       @logger.error("Functest engine failed: #{e.message}")
@@ -322,6 +326,29 @@ module AutoHCK
       @logger.info("Results written to: #{results_path}")
 
       @project.result_uploader&.upload_file(results_path, 'functest_results.json')
+    end
+
+    def pause_run_if_needed(summary = nil, exception = nil)
+      test_options = @project.options.test
+
+      auto_manual_need = test_options.auto_manual &&
+                         (!exception.nil? || (summary && summary[:failed].positive?))
+
+      @logger.debug("Switch to manual mode check: manual=#{test_options.manual} auto_manual_need=#{auto_manual_need}")
+      return unless test_options.manual || auto_manual_need
+
+      pause_run
+    end
+
+    def pause_run
+      @project.logger.info('AutoHCK switched in manual mode. Waiting for manual exit.')
+      @project.logger.info("Type 'exit' and press ENTER to exit manual mode")
+
+      # rubocop:disable Lint/Debugger
+      binding.irb
+      # rubocop:enable Lint/Debugger
+
+      @project.logger.info('Manual exit. AutoHCK will continue.')
     end
   end
 end


### PR DESCRIPTION
Add `--manual `and `--auto-manual` CLI options to the functest engine, mirroring the existing hcktest behavior.
`--manual` pauses after all tests complete, dropping into an IRB shell before VM teardown for manual inspection.
`--auto-manual` does the same but only when a failure or exception occurs.