### PR TITLE
Functest: support extra_software on test case level

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -174,6 +174,7 @@ A test case defines an ordered sequence of steps and optional cleanup steps. Cas
 | `name` | Yes | Test case name; shown in results and log output |
 | `description` | No | Human-readable description |
 | `test_system_ref` | No | Reference to an issue or ticket |
+| `extra_software` | No | List of software packages to install on the guest before any tests run |
 | `pre_test_commands` | No | Steps run before test start; a failure aborts remaining steps |
 | `cycles` | No | Allow to repeat test_steps several times |
 | `test_steps` | Yes | Ordered array of step objects; a failure aborts remaining steps |

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -260,6 +260,7 @@ module AutoHCK
       extra_softwares = @drivers.flat_map(&:extra_software)
       extra_softwares += @project.engine_platform.extra_software
       extra_softwares += @suite.requirements.extra_software if @suite
+      extra_softwares += @tests.flat_map(&:extra_software)
 
       @project.extra_sw_manager.prepare_software_packages(
         extra_softwares, @project.engine_platform.kit, ENGINE_MODE

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -12,6 +12,7 @@ module AutoHCK
       const :description, T.nilable(String)
       const :test_system_ref, T.nilable(String)
       const :timeout, T.nilable(Integer)
+      const :extra_software, T::Array[String], default: []
       const :pre_test_commands, T::Array[Models::CommandInfo], default: []
       const :cycles, Integer, default: 1
       prop :test_steps, T::Array[Models::CommandInfo]


### PR DESCRIPTION
Add extra_software field to TestCase, allowing individual test cases to declare required guest software packages. Packages are collected from all loaded test cases and installed before any tests run.