### PR TITLE
Add extension for memory leak detection

### DIFF
--- a/lib/engines/functest/tests/scripts/check_driver_verifier_active.ps1
+++ b/lib/engines/functest/tests/scripts/check_driver_verifier_active.ps1
@@ -1,0 +1,17 @@
+# Verify Driver Verifier is active for @driver_module@.sys.
+# Used by memory_leak_check extension to fail early with a clear message
+# when driver_verifier extension is missing or ordered incorrectly.
+
+$ErrorActionPreference = 'Continue'
+$driver = '@driver_module@'
+
+$status = cmd /c "verifier /querysettings 2>&1" | Out-String
+if ($status -notmatch [regex]::Escape($driver)) {
+    throw @"
+Driver Verifier is not active for $driver.sys — memory_leak_check requires it.
+Use: --extensions memory_leak_check,driver_verifier
+  (order matters: memory_leak_check must come BEFORE driver_verifier)
+"@
+}
+
+Write-Output "PASS: Driver Verifier confirmed active for $driver.sys"

--- a/lib/engines/functest/tests/scripts/disable_driver_device.ps1
+++ b/lib/engines/functest/tests/scripts/disable_driver_device.ps1
@@ -1,0 +1,26 @@
+# Disable the @driver_module@ PnP device (unloads the driver).
+# When Driver Verifier is active, unloading triggers pool tag verification —
+# a pool leak causes a BSOD (bugcheck 0xC4).
+
+$ErrorActionPreference = 'Stop'
+$driver = '@driver_module@'
+
+$dev = Get-PnpDevice | Where-Object {
+    $_.Status -eq 'OK' -and (
+        ($_ | Get-PnpDeviceProperty -KeyName 'DEVPKEY_Device_Service' -ErrorAction SilentlyContinue).Data -eq $driver
+    )
+} | Select-Object -First 1
+
+if (-not $dev) {
+    throw "No active PnP device found for driver service '$driver'"
+}
+
+Write-Output "Disabling device: $($dev.FriendlyName) [$($dev.InstanceId)]"
+Disable-PnpDevice -InstanceId $dev.InstanceId -Confirm:$false
+
+$check = Get-PnpDevice -InstanceId $dev.InstanceId
+if ($check.Status -eq 'OK') {
+    throw "Device still active after disable: $($check.InstanceId)"
+}
+
+Write-Output "PASS: $driver device disabled ($($dev.FriendlyName))"

--- a/lib/engines/functest/tests/scripts/enable_driver_device.ps1
+++ b/lib/engines/functest/tests/scripts/enable_driver_device.ps1
@@ -1,0 +1,34 @@
+# Re-enable the @driver_module@ PnP device after a memory leak check.
+
+$ErrorActionPreference = 'Stop'
+$driver = '@driver_module@'
+
+$dev = Get-PnpDevice | Where-Object {
+    $_.Status -ne 'OK' -and (
+        ($_ | Get-PnpDeviceProperty -KeyName 'DEVPKEY_Device_Service' -ErrorAction SilentlyContinue).Data -eq $driver
+    )
+} | Select-Object -First 1
+
+if (-not $dev) {
+    Write-Output "FAIL: No disabled PnP device found for driver service '$driver'"
+    exit 1
+}
+
+Write-Output "Enabling device: $($dev.FriendlyName) [$($dev.InstanceId)]"
+Enable-PnpDevice -InstanceId $dev.InstanceId -Confirm:$false -ErrorAction SilentlyContinue
+
+$timeout = 30
+$elapsed = 0
+while ($elapsed -lt $timeout) {
+    $check = Get-PnpDevice -InstanceId $dev.InstanceId
+    if ($check.Status -eq 'OK') {
+        Write-Output "PASS: $driver device re-enabled ($($dev.FriendlyName))"
+        exit 0
+    }
+    Start-Sleep -Seconds 3
+    $elapsed += 3
+}
+
+$check = Get-PnpDevice -InstanceId $dev.InstanceId
+Write-Output "FAIL: Device not active after enable (waited ${timeout}s): $($check.InstanceId) status=$($check.Status)"
+exit 1

--- a/lib/engines/hcktest/extensions/memory_leak_check.json
+++ b/lib/engines/hcktest/extensions/memory_leak_check.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "Use with driver_verifier: --extensions memory_leak_check,driver_verifier (order matters — leak check post commands must run before verifier is disabled)",
+  "tests_config": [
+    {
+      "tests": [".*"],
+      "post_test_commands": [
+        {
+          "desc": "Verify Driver Verifier is active (requires driver_verifier extension)",
+          "guest_run_file": "lib/engines/functest/tests/scripts/check_driver_verifier_active.ps1",
+          "expected_output_contains": "PASS:",
+          "timeout": 30
+        },
+        {
+          "desc": "Disable @driver_module@ device to trigger verifier pool check",
+          "guest_run_file": "lib/engines/functest/tests/scripts/disable_driver_device.ps1",
+          "expected_output_contains": "PASS:",
+          "timeout": 60
+        },
+        {
+          "desc": "Wait for verifier pool tag verification (BSOD on leak)",
+          "guest_run": "Start-Sleep -Seconds 10; Write-Output 'PASS: VM alive after driver unload — no pool leak detected'",
+          "expected_output_contains": "PASS:",
+          "timeout": 30
+        },
+        {
+          "desc": "Re-enable @driver_module@ device",
+          "guest_run_file": "lib/engines/functest/tests/scripts/enable_driver_device.ps1",
+          "expected_output_contains": "PASS:",
+          "timeout": 60
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
With extension support [landing](https://github.com/HCK-CI/AutoHCK/pull/1068), adding memory leak detection similar to how tp-qemu handles the check for fwcfg64 [1,2].  Since this is CLI enabled and dependent on `driver_verifier` being configured as well, also included a script that checks for dv and fails with appropriate message: `lib/engines/functest/tests/scripts/check_driver_verifier_active.ps1`.  Example execution:


`bin/auto_hck --verbose functest -p Win2022x64 --driver-path <path-to-driver>  -d fwcfg64 --extensions memory_leak_check,driver_verifier --testcase fwcfg64/dump_and_analyze`



[1] https://github.com/autotest/tp-qemu/blob/master/qemu/tests/fwcfg.py#L78
[2] https://github.com/autotest/tp-qemu/blob/master/provider/win_driver_utils.py#L448