### PR TITLE
functest: add dummy test suite for CI validation

### DIFF
--- a/jenkins/test_func_dummy_ci.sh
+++ b/jenkins/test_func_dummy_ci.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+test_name="$(basename "${0}" '.sh')"
+
+cd "${WORKSPACE}"
+
+# Create a temporary directory with a known marker file to exercise --test-binaries-path
+tmp_test_binaries="$(mktemp -d)"
+echo "dummy_ci" > "${tmp_test_binaries}/dummy_ci_marker.txt"
+trap 'rm -rf "$tmp_test_binaries"' EXIT
+
+bin/auto_hck --verbose functest \
+    --platform Win2025x64 \
+    --test-binaries-path "${tmp_test_binaries}" \
+    --category dummy \
+    --gthb_context_prefix "${test_name}: " \
+    --commit "${GITHUB_COMMIT}"
+
+cat "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"
+# Check that all 5 test cases passed
+grep -e '"passed": 5,' "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"

--- a/lib/engines/functest/tests/cases/dummy_ci/snapshot_clean_boot.json
+++ b/lib/engines/functest/tests/cases/dummy_ci/snapshot_clean_boot.json
@@ -1,0 +1,13 @@
+{
+    "name": "snapshot_clean_boot",
+    "description": "Boot from the clean base image and verify the marker file is absent",
+    "clean_boot": true,
+    "test_steps": [
+        {
+            "desc": "Verify marker file is absent after clean boot",
+            "guest_run": "if (Test-Path 'C:\\ci_marker.txt') { throw 'marker file unexpectedly present after clean boot' }; Write-Output 'PASS: no marker file on clean boot'",
+            "expected_output_contains": "PASS:",
+            "timeout": 30
+        }
+    ]
+}

--- a/lib/engines/functest/tests/cases/dummy_ci/snapshot_create.json
+++ b/lib/engines/functest/tests/cases/dummy_ci/snapshot_create.json
@@ -1,0 +1,13 @@
+{
+    "name": "snapshot_create",
+    "description": "Create a marker file in the guest and save a named VM snapshot",
+    "save_snapshot_as": "with_marker",
+    "test_steps": [
+        {
+            "desc": "Create marker file in guest",
+            "guest_run": "Set-Content -Path 'C:\\ci_marker.txt' -Value 'dummy_ci'; Write-Output 'PASS: marker file created'",
+            "expected_output_contains": "PASS:",
+            "timeout": 30
+        }
+    ]
+}

--- a/lib/engines/functest/tests/cases/dummy_ci/snapshot_restore.json
+++ b/lib/engines/functest/tests/cases/dummy_ci/snapshot_restore.json
@@ -1,0 +1,13 @@
+{
+    "name": "snapshot_restore",
+    "description": "Boot from the saved snapshot and verify the marker file is present",
+    "boot_from_snapshot_tag": "with_marker",
+    "test_steps": [
+        {
+            "desc": "Verify marker file is present after restoring snapshot",
+            "guest_run": "if (Test-Path 'C:\\ci_marker.txt') { Write-Output 'PASS: marker file present in snapshot' } else { throw 'marker file missing after snapshot restore' }",
+            "expected_output_contains": "PASS:",
+            "timeout": 30
+        }
+    ]
+}

--- a/lib/engines/functest/tests/cases/dummy_ci/variable_to_file.json
+++ b/lib/engines/functest/tests/cases/dummy_ci/variable_to_file.json
@@ -1,0 +1,30 @@
+{
+    "name": "variable_to_file",
+    "description": "Set a variable, write its value to a file in the guest, copy the file to the host, and verify its content",
+    "test_steps": [
+        {
+            "desc": "Set test variable",
+            "set_variable": { "test_value": "dummy_ci_test_data" }
+        },
+        {
+            "desc": "Write test variable value to a file in guest",
+            "guest_run": "Set-Content -Path 'C:\\ci_output.txt' -Value '@test_value@'; Write-Output 'PASS: file written'",
+            "expected_output_contains": "PASS:",
+            "timeout": 30
+        },
+        {
+            "desc": "Copy output file from guest to host workspace",
+            "files_action": [
+                {
+                    "local_path": "@workspace@/ci_output.txt",
+                    "remote_path": "C:\\ci_output.txt",
+                    "direction": "remote-to-local"
+                }
+            ]
+        },
+        {
+            "desc": "Verify file content on host contains the test variable value",
+            "host_run": "grep -qF @test_value@ ci_output.txt"
+        }
+    ]
+}

--- a/lib/engines/functest/tests/cases/dummy_ci/workspace_check.json
+++ b/lib/engines/functest/tests/cases/dummy_ci/workspace_check.json
@@ -1,0 +1,22 @@
+{
+    "name": "workspace_check",
+    "description": "Verify host workspace snapshot files, workspace path engine tag, and guest test_binaries_dir",
+    "test_steps": [
+        {
+            "desc": "Verify workspace contains snapshot qcow2 files",
+            "host_run": "ls *-snapshot.qcow2",
+            "expected_output_contains": "-snapshot.qcow2"
+        },
+        {
+            "desc": "Verify workspace path contains expected engine tag prefix",
+            "host_run": "echo $PWD",
+            "expected_output_matches": "dummy-"
+        },
+        {
+            "desc": "Verify test_binaries_dir content was uploaded to guest",
+            "guest_run": "if (Test-Path '@test_binaries_dir@\\dummy_ci_marker.txt') { Write-Output 'PASS: test binaries uploaded' } else { throw 'dummy_ci_marker.txt not found in @test_binaries_dir@' }",
+            "expected_output_contains": "PASS:",
+            "timeout": 30
+        }
+    ]
+}

--- a/lib/engines/functest/tests/suites/dummy.json
+++ b/lib/engines/functest/tests/suites/dummy.json
@@ -1,0 +1,11 @@
+{
+    "name": "dummy",
+    "description": "Dummy CI test suite for functest engine validation: snapshot lifecycle, workspace inspection, and variable-to-file",
+    "tests": [
+        "dummy_ci/snapshot_create",
+        "dummy_ci/snapshot_clean_boot",
+        "dummy_ci/snapshot_restore",
+        "dummy_ci/workspace_check",
+        "dummy_ci/variable_to_file"
+    ]
+}


### PR DESCRIPTION
Adds a no-driver test suite to verify functest engine works correctly. Tests cover VM snapshots, host workspace checks, file uploads to guest, and reading data back to the host.