### PR TITLE
Functest: keep_alive + wait_client_online after ACPI SHUTDOWN

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -262,7 +262,7 @@ See [`lib/engines/functest/tests/cases/driver_sign_check.json`](../lib/engines/f
 
 ## Step Types
 
-> Each step object must have **exactly one** step-type field (`guest_run`, `guest_run_file`, `guest_reboot`, `host_run`, `host_run_file`, `files_action`, `qmp_command`, `qmp_wait_event`, `barrier`, `set_variable`). All other fields are optional modifiers.
+> Each step object must have **exactly one** step-type field (`guest_run`, `guest_run_file`, `guest_reboot`, `host_run`, `host_run_file`, `files_action`, `qmp_command`, `qmp_wait_event`, `wait_client_online`, `barrier`, `set_variable`). All other fields are optional modifiers.
 
 ### Common Step Fields
 
@@ -276,7 +276,7 @@ See [`lib/engines/functest/tests/cases/driver_sign_check.json`](../lib/engines/f
 | `expected_output_contains` | The step fails if the output does not contain this string. Only for `guest_run`/`guest_run_file`/`host_run`/`host_run_file`. Checked against every client the step ran on. |
 | `expected_output_matches` | The step fails if the output does not match this regex. Only for `guest_run`/`guest_run_file`/`host_run`/`host_run_file`. Checked against every client the step ran on. |
 | `expected_output_matches_encoding` | Controls regex encoding options for `expected_output_matches`. Currently only `Regexp::NOENCODING` is supported (binary match). Do not set to use default encoding. |
-| `clients` | Client ids (e.g. `[2]`) this step targets. Applies to `guest_run`/`guest_run_file`, `guest_reboot`, `files_action`, `qmp_command`, `qmp_wait_event`; `host_run`/`host_run_file` always run once on the host regardless. Omitted/empty broadcasts to every client booted for the test case. See [Multi-Client Support](#multi-client-support). |
+| `clients` | Client ids (e.g. `[2]`) this step targets. Applies to `guest_run`/`guest_run_file`, `guest_reboot`, `files_action`, `qmp_command`, `qmp_wait_event`, `wait_client_online`; `host_run`/`host_run_file` always run once on the host regardless. Omitted/empty broadcasts to every client booted for the test case. See [Multi-Client Support](#multi-client-support). |
 
 ---
 
@@ -430,6 +430,22 @@ Blocks until one of the given QEMU events is received from the client VM. `event
 | `timeout` | No | Maximum seconds to wait. Defaults to the engine `default_timeout`. |
 
 > Use `capture_output` to record which event actually fired (the full event payload, including its `event` name, is captured) so a later step can branch on it.
+
+---
+
+### `wait_client_online`
+
+Blocks until WinRM is reachable on the target client(s). Use after an intentional guest ACPI poweroff / QMP `SHUTDOWN` when the VM was started with functest `keep_alive` (QEMU restarts; Windows must finish booting before the next step or minidump collection).
+
+```json
+{
+    "desc": "Wait for client online after keep_alive QEMU restart",
+    "wait_client_online": true,
+    "timeout": 600
+}
+```
+
+If the guest never returns, the step fails (and the run stops) — dump collection stays strict and is not skipped.
 
 ---
 

--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -26,7 +26,7 @@ module AutoHCK
 
     STEP_TYPE_FIELDS = T.let(%i[
       guest_run guest_run_file guest_reboot files_action host_run host_run_file
-      barrier set_variable qmp_command qmp_wait_event
+      barrier set_variable qmp_command qmp_wait_event wait_client_online
     ].freeze, T::Array[Symbol])
 
     sig { params(init_opts: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
@@ -91,6 +91,7 @@ module AutoHCK
       execute_barrier(command_info) if command_info.barrier
       result[:qmp_result] = execute_qmp_command(command_info, replacement) if command_info.qmp_command
       result[:qmp_event] = execute_qmp_wait_event(command_info) if command_info.qmp_wait_event
+      execute_wait_client_online(command_info) if command_info.wait_client_online
 
       result
     end
@@ -293,6 +294,14 @@ module AutoHCK
       end
 
       outputs
+    end
+
+    sig { params(command_info: Models::CommandInfo).void }
+    def execute_wait_client_online(command_info)
+      target_machines(command_info).each do |machine_name|
+        @logger.info("Waiting for client #{machine_name} to come online")
+        @tools.wait_for_client_online(machine_name)
+      end
     end
 
     sig do

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -150,7 +150,10 @@ module AutoHCK
                               'in the platform configuration'
         end
 
-        @project.setup_manager.run_functest_client(scope, client.name)
+        # Same as HCKTest run_clients(..., keep_alive: true): guest ACPI
+        # poweroff / QMP SHUTDOWN exits QEMU; restart so mid-batch cases
+        # (e.g. netkvm_hotplug_shutdown) can continue on a live client.
+        @project.setup_manager.run_functest_client(scope, client.name, { keep_alive: true })
       end
     end
 

--- a/lib/engines/functest/step_handler.rb
+++ b/lib/engines/functest/step_handler.rb
@@ -52,7 +52,7 @@ module AutoHCK
         value = step.public_send(field)
         case field
         when :files_action then value.any?
-        when :guest_reboot then value == true
+        when :guest_reboot, :wait_client_online then value == true
         when :set_variable then value.is_a?(Hash) && !value.empty?
         when :guest_run, :guest_run_file, :host_run, :host_run_file, :barrier
           value.is_a?(String) ? !value.empty? : !value.nil?

--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -262,6 +262,12 @@ module AutoHCK
       raise ToolsHCKError, 'Unimplemented method: restart_machine_and_wait'
     end
 
+    # Poll until WinRM is reachable. FunctestTools implements this; used by
+    # the wait_client_online step after ACPI poweroff + keep_alive restart.
+    def wait_for_client_online(_machine)
+      raise ToolsHCKError, 'Unimplemented method: wait_for_client_online'
+    end
+
     def restart_machine(machine)
       retries ||= 0
       act_with_tools { _1.machine_shutdown(machine, restart: true) }

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -81,6 +81,9 @@ module AutoHCK
       const :set_variable, T.nilable(T::Hash[String, String])
       const :qmp_command, T.nilable(QmpCommandConfig)
       const :qmp_wait_event, T.nilable(QmpWaitEventConfig)
+      # Block until WinRM is reachable again (e.g. after ACPI poweroff when
+      # the VM was started with keep_alive and QEMU has restarted).
+      const :wait_client_online, T::Boolean, default: false
 
       const :expected_output_contains, T.nilable(String)
       const :expected_output_matches, T.nilable(String)


### PR DESCRIPTION
## Summary

Functest guest recovery after intentional ACPI / QMP `SHUTDOWN` so mid-batch NetKVM hotplug cases can continue.

### Problem
Some NetKVM functest cases intentionally power off the guest (`shutdown /s /t 0 /f`) and wait for QMP **SHUTDOWN**. That **exits QEMU**.

Functest used to boot clients **without** `keep_alive`. After those cases, CL1 stayed dead. Post-test minidump probing hit WinRM (`No route to host`) and **aborted the whole batch**, so later cases never ran.

### Testcases this fixes

| Testcase | Polarion / KAR | Why it needs this |
|----------|----------------|-------------------|
| `NetKVM/netkvm_hotplug_shutdown` | VIRT-95886 / KAR `pci_hotplug.with_shutdown` | Hot-plug NIC, then **clean guest shutdown** + QMP `SHUTDOWN` |
| `NetKVM/netkvm_hotplug_unplug_shutdown` | VIRT-95888 / KAR nic hotplug + shutdown after unplug | Hot-plug, unplug, then **clean guest shutdown** + QMP `SHUTDOWN` |
| `NetKVM/netkvm_hotplug_unplug_reboot` (downstream in same run) | VIRT-95889 / reboot after unplug | Does **not** use SHUTDOWN itself, but **fails to start** if a prior shutdown case left QEMU dead |

### What we changed (FW) and why

| Change | Why |
|--------|-----|
| Boot functest clients with `keep_alive: true` (same idea as HCKTest) | After ACPI/`SHUTDOWN`, **restart QEMU** so the guest can boot again mid-batch |
| New step `wait_client_online: true` | Explicitly wait until **WinRM is up** after QEMU restart before next steps/minidump — dumps stay strict; if guest never returns, the step **fails loudly** |
| Docs + Tools stub for `wait_for_client_online` | FunctestTools implements the wait; base Tools gets a clear stub |

Companion case JSON updates (add `wait_client_online` after QMP `SHUTDOWN`) live in the functional-tests NetKVM cases.

## Test plan

- [x] Re-run with `--pcie-spare-root-ports 1`:
  `NetKVM/netkvm_hotplug_shutdown,NetKVM/netkvm_hotplug_unplug_shutdown,NetKVM/netkvm_hotplug_unplug_reboot`
- [x] Confirm log shows `Waiting for client CL1 to come online` after both SHUTDOWN cases
- [x] Confirm **3/3 PASSED**

### Pass log

```
I, [2026-08-04T14:18:55.834075 #3193375]  INFO -- : Waiting for client CL1 to come online
I, [2026-08-04T14:19:34.838514 #3193375]  INFO -- : PASSED: netkvm_hotplug_shutdown
I, [2026-08-04T14:20:04.469208 #3193375]  INFO -- : Waiting for client CL1 to come online
I, [2026-08-04T14:20:43.474416 #3193375]  INFO -- : PASSED: netkvm_hotplug_unplug_shutdown
I, [2026-08-04T14:21:34.123596 #3193375]  INFO -- : PASSED: netkvm_hotplug_unplug_reboot
I, [2026-08-04T14:21:35.649054 #3193375]  INFO -- : TEST SUMMARY
I, [2026-08-04T14:21:35.649106 #3193375]  INFO -- : Total:  3
I, [2026-08-04T14:21:35.649127 #3193375]  INFO -- : Passed: 3
I, [2026-08-04T14:21:35.649149 #3193375]  INFO -- : Failed: 0
```

Command used:

```
./bin/auto_hck --id 58 functest -p Win2025x64 -d NetKVM \
  --driver-path <NetKVM/2k25/amd64> \
  --pcie-spare-root-ports 1 \
  --testcase NetKVM/netkvm_hotplug_shutdown,NetKVM/netkvm_hotplug_unplug_shutdown,NetKVM/netkvm_hotplug_unplug_reboot
```

Made with [Cursor](https://cursor.com)