### PR TITLE
Add --virtio-queues and --virtio-vectors CLI options

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -127,6 +127,8 @@ module AutoHCK
     prop :drive_aio_state, T.nilable(String)
     prop :discard_granularity, T.nilable(String)
     prop :fs_daemon_cache_mode, T.nilable(String)
+    prop :virtio_vectors, T.nilable(Integer)
+    prop :virtio_queues, T.nilable(Integer)
     prop :pcie_spare_root_ports, T.nilable(Integer)
     prop :test_params, T::Hash[String, String], default: {}
 
@@ -332,6 +334,17 @@ module AutoHCK
       parser.on('--virtiofs-cache <mode>', %w[auto always never],
                 'Set virtiofsd cache mode for the virtio-fs device (default: always)',
                 &method(:fs_daemon_cache_mode=))
+
+      parser.on('--virtio-vectors <N>', Integer,
+                'Set MSI-X vectors on the virtio device under test.',
+                'Supported by all virtio-pci devices.',
+                'QEMU auto-assigns vectors; use this to override.',
+                &method(:virtio_vectors=))
+
+      parser.on('--virtio-queues <N>', Integer,
+                'Set virtqueues on the virtio device under test.',
+                'Supported devices: virtio-net-pci, virtio-scsi-pci, virtio-blk-pci.',
+                &method(:virtio_queues=))
 
       parser.on('--pcie-spare-root-ports <N>', Integer,
                 'Allocate N extra empty pcie-root-ports at boot for later hotplug (q35 only, default: 0)',

--- a/lib/setupmanagers/qemuhck/devices/virtio-balloon-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-balloon-pci.json
@@ -1,5 +1,5 @@
 {
   "name": "virtio-balloon-pci",
   "need_pci_bus": true,
-  "command_line": ["-device virtio-balloon-pci@device_extra_param@@iommu_device_param@,bus=@bus_name@.0"]
+  "command_line": ["-device virtio-balloon-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,bus=@bus_name@.0"]
 }

--- a/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-blk-pci.json
@@ -11,7 +11,7 @@
   ],
   "command_line": [
     "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_blk_@run_id@_@client_id@_@storage_dev_id@@drive_cache_options@@drive_discard_param@",
-    "-device virtio-blk-pci@device_extra_param@@iommu_device_param@@blk_discard_granularity_param@,id=virtio_blk_@run_id@_@client_id@_@storage_dev_id@_dev,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@_@storage_dev_id@,serial=@client_id@blk@run_id@@bootindex@",
+    "-device virtio-blk-pci@device_extra_param@@virtio_blk_queues_param@@virtio_vectors_param@@iommu_device_param@@blk_discard_granularity_param@,id=virtio_blk_@run_id@_@client_id@_@storage_dev_id@_dev,bus=@bus_name@.0,drive=virtio_blk_@run_id@_@client_id@_@storage_dev_id@,serial=@client_id@blk@run_id@@bootindex@",
     "-chardev socket,id=blk_qmp,path=@blk_qmp_socket@,server=on,wait=off",
     "-mon chardev=blk_qmp,mode=control"
   ]

--- a/lib/setupmanagers/qemuhck/devices/virtio-keyboard-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-keyboard-pci.json
@@ -1,5 +1,5 @@
 {
   "name": "virtio-keyboard-pci",
   "need_pci_bus": true,
-  "command_line": ["-device virtio-keyboard-pci@device_extra_param@@iommu_device_param@,bus=@bus_name@.0"]
+  "command_line": ["-device virtio-keyboard-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,bus=@bus_name@.0"]
 }

--- a/lib/setupmanagers/qemuhck/devices/virtio-mem-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-mem-pci.json
@@ -4,7 +4,7 @@
   "need_pci_bus": true,
   "command_line": [
     "-object memory-backend-ram,id=mem_viomem_@run_id@_@client_id@,size=@viomem_boot_backend_size@",
-    "-device virtio-mem-pci@device_extra_param@@iommu_device_param@,id=mem_@run_id@_@client_id@,memdev=mem_viomem_@run_id@_@client_id@,node=@viomem_numa_node@,requested-size=1G,bus=@bus_name@.0"
+    "-device virtio-mem-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,id=mem_@run_id@_@client_id@,memdev=mem_viomem_@run_id@_@client_id@,node=@viomem_numa_node@,requested-size=1G,bus=@bus_name@.0"
   ],
   "define_variables": {
     "@viomem_numa_node@": "0",

--- a/lib/setupmanagers/qemuhck/devices/virtio-net-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-net-pci.json
@@ -4,6 +4,6 @@
   "need_pci_bus": true,
   "command_line": [
     "-netdev @network_backend@,id=@net_if_name@@netdev_options@",
-    "-device virtio-net-pci@device_extra_param@@iommu_device_param@,netdev=@net_if_name@,mac=@net_if_mac@@net_addr@,speed=@speed@,bus=@bus_name@.0,id=@net_if_name@"
+    "-device virtio-net-pci@device_extra_param@@virtio_net_queues_param@@virtio_vectors_param@@iommu_device_param@,netdev=@net_if_name@,mac=@net_if_mac@@net_addr@,speed=@speed@,bus=@bus_name@.0,id=@net_if_name@"
   ]
 }

--- a/lib/setupmanagers/qemuhck/devices/virtio-rng-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-rng-pci.json
@@ -1,5 +1,5 @@
 {
   "name": "virtio-rng-pci",
   "need_pci_bus": true,
-  "command_line": ["-device virtio-rng-pci@device_extra_param@@iommu_device_param@,bus=@bus_name@.0"]
+  "command_line": ["-device virtio-rng-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,bus=@bus_name@.0"]
 }

--- a/lib/setupmanagers/qemuhck/devices/virtio-scsi-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-scsi-pci.json
@@ -11,7 +11,7 @@
   ],
   "command_line": [
     "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_scsi_@run_id@_@client_id@@drive_cache_options@",
-    "-device virtio-scsi-pci@device_extra_param@@iommu_device_param@,id=scsi,bus=@bus_name@.0",
+    "-device virtio-scsi-pci@device_extra_param@@virtio_scsi_queues_param@@virtio_vectors_param@@iommu_device_param@,id=scsi,bus=@bus_name@.0",
     "-device scsi-hd,drive=virtio_scsi_@run_id@_@client_id@,serial=@client_id@scsi@run_id@@bootindex@",
     "-chardev socket,id=scsi_qmp,path=@scsi_qmp_socket@,server=on,wait=off",
     "-mon chardev=scsi_qmp,mode=control"

--- a/lib/setupmanagers/qemuhck/devices/virtio-serial-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-serial-pci.json
@@ -1,5 +1,5 @@
 {
   "name": "virtio-serial-pci",
   "need_pci_bus": true,
-  "command_line": ["-device virtio-serial-pci@device_extra_param@@iommu_device_param@,bus=@bus_name@.0,id=virtio_serial_pci0"]
+  "command_line": ["-device virtio-serial-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,bus=@bus_name@.0,id=virtio_serial_pci0"]
 }

--- a/lib/setupmanagers/qemuhck/devices/virtio-vga.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-vga.json
@@ -2,5 +2,5 @@
   "name": "virtio-vga",
   "type": "vga",
   "need_pci_bus": true,
-  "command_line": ["-device virtio-vga@device_extra_param@@iommu_device_param@,edid=off,bus=@bus_name@.0"]
+  "command_line": ["-device virtio-vga@device_extra_param@@virtio_vectors_param@@iommu_device_param@,edid=off,bus=@bus_name@.0"]
 }

--- a/lib/setupmanagers/qemuhck/network_manager.rb
+++ b/lib/setupmanagers/qemuhck/network_manager.rb
@@ -187,7 +187,8 @@ module AutoHCK
       private
 
       def create_tap_device_command(type, device, bus_name, bridge_name, qemu_replacement_map)
-        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,downscript=no,ifname=@net_if_name@'
+        netdev_options = ',vhost=@vhost_value@,script=@net_up_script@,' \
+                         'downscript=no,ifname=@net_if_name@@netdev_mq_param@'
         network_backend = 'tap'
 
         options = {

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -452,6 +452,37 @@ module AutoHCK
       { '@fs_daemon_cache_mode@' => mode }
     end
 
+    # Builds MQ/vectors placeholders from --virtio-queues / --virtio-vectors.
+    #
+    # @virtio_vectors_param@        : ,vectors=N  — all virtio-pci devices;
+    #                                 QEMU auto-assigns vectors when omitted
+    # @virtio_net_queues_param@     : ,mq=on        (virtio-net-pci, when queues > 1)
+    # @virtio_scsi_queues_param@    : ,num_queues=N  (virtio-scsi-pci)
+    # @virtio_blk_queues_param@     : ,num-queues=N  (virtio-blk-pci)
+    # @netdev_mq_param@             : ,queues=N      (on -netdev tap, when queues > 1)
+    def virtio_extra_param_replacement_map
+      queues  = option_config('virtio_queues')
+      vectors = option_config('virtio_vectors')
+
+      raise QemuHCKError, '--virtio-vectors must be >= 0' if vectors&.negative?
+
+      {
+        '@virtio_vectors_param@' => vectors ? ",vectors=#{vectors}" : '',
+        '@virtio_net_queues_param@' => net_mq_queues_param(queues),
+        '@virtio_scsi_queues_param@' => queues ? ",num_queues=#{queues}" : '',
+        '@virtio_blk_queues_param@' => queues ? ",num-queues=#{queues}" : '',
+        '@netdev_mq_param@' => netdev_mq_queues_param(queues)
+      }
+    end
+
+    def net_mq_queues_param(queues)
+      queues && queues > 1 ? ',mq=on' : ''
+    end
+
+    def netdev_mq_queues_param(queues)
+      queues && queues > 1 ? ",queues=#{queues}" : ''
+    end
+
     def numa_replacement_map
       return {} unless option_config('numa_state')
 
@@ -518,6 +549,7 @@ module AutoHCK
                                              options_replacement_map,
                                              discard_granularity_replacement_map,
                                              fs_daemon_cache_mode_replacement_map,
+                                             virtio_extra_param_replacement_map,
                                              device_define_variables,
                                              numa_replacement_map,
                                              @define_variables)

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -119,6 +119,8 @@ module AutoHCK
         'drive_aio_state' => test_opt.drive_aio_state,
         'discard_granularity' => test_opt.discard_granularity,
         'fs_daemon_cache_mode' => test_opt.fs_daemon_cache_mode,
+        'virtio_vectors' => test_opt.virtio_vectors,
+        'virtio_queues' => test_opt.virtio_queues,
         'pcie_spare_root_ports' => test_opt.pcie_spare_root_ports,
         'ctrl_net_device' => common.client_ctrl_net_dev,
         'world_net_device' => common.client_world_net_dev


### PR DESCRIPTION
Allow setting virtqueues and MSI-X vectors on the virtio device under
test via CLI. Queues map to mq=on/num_queues=/num-queues= per device
type; vectors override QEMU's auto-assignment on any virtio-pci device.