### PR TITLE
[VIRTWINKVM-2679] Fix clean_boot not re-uploading test_binaries to guest

### DIFF
--- a/lib/setupmanagers/functest_client.rb
+++ b/lib/setupmanagers/functest_client.rb
@@ -26,7 +26,7 @@ module AutoHCK
     def reboot_clean
       @logger.info("Rebooting client #{@name} from a clean image")
       @runner = @setup_manager.power_cycle_client(@scope, @name, create_snapshot: true)
-      reconnect
+      prepare_machine(@tools)
     end
 
     # Boots a fresh VM from a previously saved snapshot tag.


### PR DESCRIPTION
 When a test case uses `clean_boot: true`, `reboot_clean` creates a fresh qcow2 overlay from the base image, which wipes `C:\AutoHCK\test_binaries` from the guest. Tests that reference `@test_binaries_dir@` after a   clean boot fail with "file not found". 

This fix calls `copy_test_binaries` after reconnect in reboot_clean, matching what `prepare_machine` already does during initial setup.
