### PR TITLE
Fix non-deterministic PCI topology across VM stop/start cycles

### DIFF
--- a/lib/setupmanagers/qemuhck/pci_manager.rb
+++ b/lib/setupmanagers/qemuhck/pci_manager.rb
@@ -11,9 +11,11 @@ module AutoHCK
 
       def initialize(logger)
         @logger = logger
-        @dev_id = 0
+        reset
+      end
 
-        # First free PCI slot, chassis and address
+      def reset
+        @dev_id = 0
         @pci_slot = 4
         @pci_chassis = 2
         @pci_addr = 5

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -662,6 +662,7 @@ module AutoHCK
 
     def process_device_commands
       @device_commands = []
+      @pcim.reset
 
       process_hck_network_command
       process_storage_command


### PR DESCRIPTION
`PciManager` counters (pci_slot, pci_chassis, pci_addr) were initialized once in `QemuMachine.initialize` but never reset between runs. When process_device_commands was called on VM restart, the counters continued from where they left off, producing different slot/chassis/addr assignments — and therefore different bus names (e.g., root5 on first boot, root11 on second boot).

This caused two problems after clean_boot (stop + restart):
  - Spare PCIe root port bus names (@spare_pcie_root_port_N@) changed, breaking hotplug tests that reference them
  - Network/storage devices landed on different PCI slots, causing Windows to treat them as new hardware and lose network configuration

Fix: Extract counter initialization into `PciManager#reset` and call it at the start of `process_device_commands`, matching the existing pattern of resetting `@device_commands`. This makes PCI allocation deterministic across restarts.
