### PR TITLE
Functest: Add parallel step execution

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -263,7 +263,7 @@ See [`lib/engines/functest/tests/cases/driver_sign_check.json`](../lib/engines/f
 
 ## Step Types
 
-> Each step object must have **exactly one** step-type field (`guest_run`, `guest_run_file`, `guest_reboot`, `host_run`, `host_run_file`, `files_action`, `qmp_command`, `qmp_wait_event`, `barrier`, `set_variable`). All other fields are optional modifiers.
+> Each step object must have **exactly one** step-type field (`guest_run`, `guest_run_file`, `guest_reboot`, `host_run`, `host_run_file`, `files_action`, `qmp_command`, `qmp_wait_event`, `barrier`, `set_variable`, `parallel`). All other fields are optional modifiers.
 
 ### Common Step Fields
 
@@ -461,6 +461,73 @@ Multiple variables can be set in a single step:
     "set_variable": { "disk_number": "2", "bus_slot": "0x04" }
 }
 ```
+
+---
+
+### `parallel`
+
+Runs two or more named branches at the same time, each one in its own thread. Inside a branch, its steps still run one after another, same as normal `test_steps`. The engine always waits for every branch to finish (or stop) before moving on to the next step.
+
+Here's an example with two branches, one on the host and one on the guest:
+
+```json
+{
+    "desc": "Say hello from host and guest at the same time",
+    "parallel": {
+        "branches": {
+            "host_branch": [
+                { "desc": "Say hello from host", "host_run": "echo 'hello from host'" }
+            ],
+            "guest_branch": [
+                { "desc": "Say hello from guest", "guest_run": "Write-Output 'hello from guest'" }
+            ]
+        }
+    }
+}
+```
+
+#### `parallel` Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `branches` | Yes | An object mapping a branch name to its own ordered list of steps. Every branch runs at the same time as every other branch in the block. |
+| `fail_fast` | No | Default: `true`. If a branch fails, every other still-running branch is stopped too (a branch always finishes the step it's currently on first, then stops before starting its next one). Set to `false` to let every branch run to the end no matter what fails elsewhere. Either way, the `parallel` step only fails once every branch has stopped. |
+
+The step's own `timeout` (engine default if unset) is the deadline for the **whole block**, not just one branch — a branch's own steps still keep their own `timeout` inside that. If the deadline is hit, any branches still running are stopped right away and the step fails with a timeout error.
+
+#### Constraints
+
+These are checked before the test's own steps start running, so a bad `parallel` block always fails immediately with a clear error, instead of failing partway through a real run:
+
+- A `parallel` block needs at least two branches.
+- Every branch step must resolve to exactly one step type (same rule as any other step), and it must be one of the types allowed inside a parallel branch.
+- Two branches can't target the same client. A branch "targets" whatever clients its `guest_run`/`guest_run_file`/`files_action`/`qmp_command`/`qmp_wait_event` steps target. `host_run`/`host_run_file` don't target a client, so any number of branches can run those at once.
+- A branch can't contain another `parallel` step. No nesting.
+- A branch can't use `guest_reboot` or `set_variable`. Do these outside the `parallel` block instead.
+- `capture_output` names must be different across every branch in the block. Two branches capturing to the same name is almost always a mistake, so it's rejected up front instead of letting one silently overwrite the other. Reusing a name across sequential steps within the *same* branch is fine.
+- A `parallel` step can't also have another step-type field, like `guest_run`, on the same step object.
+
+#### Variable capture
+
+While a branch is running, its `capture_output` values are only visible to later steps in that same branch — other branches can't see them yet. When the block completes without timing out, captured variables from branches that did not fail are added to the shared test context and become available to every later step (this is safe because of the uniqueness rule above). Captures from a failed branch are discarded; if the whole block times out, no branch's captures are published.
+
+#### Result reporting
+
+In `functest_results.json`, a `parallel` step also gets a `branches` key showing what each branch did:
+
+```json
+{
+    "index": 3,
+    "description": "Say hello from host and guest at the same time",
+    "status": "passed",
+    "branches": {
+        "host_branch": { "status": "passed", "steps": [ { "index": 0, "description": "Say hello from host", "status": "passed", "start_time": "...", "end_time": "...", "duration": 0.05 } ] },
+        "guest_branch": { "status": "passed", "steps": [ { "index": 0, "description": "Say hello from guest", "status": "passed", "start_time": "...", "end_time": "...", "duration": 0.08 } ] }
+    }
+}
+```
+
+A branch that `fail_fast` stopped early (because another branch failed first) gets `"status": "cancelled"` instead, with whatever steps it managed to run before stopping (possibly none). A branch still running when the whole block's own timeout expires gets `"status": "timeout"`, likewise with whatever steps it managed to finish first.
 
 ---
 

--- a/jenkins/test_func_dummy_ci.sh
+++ b/jenkins/test_func_dummy_ci.sh
@@ -19,5 +19,5 @@ bin/auto_hck --verbose functest \
     --commit "${GITHUB_COMMIT}"
 
 cat "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"
-# Check that all 6 test cases passed
-grep -e '"passed": 6,' "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"
+# Check that all 7 test cases passed
+grep -e '"passed": 7,' "${AUTO_HCK_WORKSPACE_PATH}/latest/functest_results.json"

--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -27,7 +27,7 @@ module AutoHCK
 
     STEP_TYPE_FIELDS = T.let(%i[
       guest_run guest_run_file guest_reboot files_action host_run host_run_file
-      barrier set_variable qmp_command qmp_wait_event engine_setup_manager_action
+      barrier set_variable qmp_command qmp_wait_event engine_setup_manager_action parallel
     ].freeze, T::Array[Symbol])
 
     sig { params(init_opts: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }

--- a/lib/engines/functest/branch_context.rb
+++ b/lib/engines/functest/branch_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module AutoHCK
+  module Functest
+    # A TestContext for one parallel branch. Reads see a snapshot of the
+    # parent's variables; writes are buffered in #pending_captures instead
+    # of the parent's shared state, so concurrent branches never race.
+    class BranchContext < TestContext
+      attr_reader :pending_captures
+
+      def initialize(parent_context)
+        super(parent_context.project, parent_context.replacement_map)
+        @pending_captures = {}
+      end
+
+      # Used by capture_output, the only way a branch writes a variable.
+      def set_variable(name, value)
+        super
+        @pending_captures[name] = value.to_s
+      end
+    end
+  end
+end

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -2,8 +2,10 @@
 # frozen_string_literal: true
 
 require_relative 'test_context'
+require_relative 'branch_context'
 require_relative 'test_loader'
 require_relative 'step_handler'
+require_relative 'parallel_branch_runner'
 require_relative 'test_executor'
 
 module AutoHCK

--- a/lib/engines/functest/parallel_branch_runner.rb
+++ b/lib/engines/functest/parallel_branch_runner.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+module AutoHCK
+  module Functest
+    # Runs the branches of one `parallel` step at the same time, each fully
+    # isolated from the others until they've all finished. Captured
+    # variables only become visible to the rest of the test once every
+    # branch is done. See ParallelBlock#fail_fast for cancellation rules.
+    class ParallelBranchRunner
+      # branch_name => { status:, steps: [{ index:, description:, status:,
+      # start_time:, end_time:, duration:, error: }] }
+      attr_reader :branch_results
+
+      # A branch's identity
+      Branch = Struct.new(:name, :context, keyword_init: true)
+
+      def initialize(project, command_execution_manager, context, logger, default_timeout)
+        @project = project
+        @command_execution_manager = command_execution_manager
+        @context = context
+        @logger = logger
+        @default_timeout = default_timeout
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def run(step)
+        branches = step.parallel.branches
+        @logger.info("Starting parallel block (branches: #{branches.keys.join(', ')})")
+
+        state = new_run_state
+        @branch_results = state[:branch_results]
+        threads = start_branch_threads(branches, step.parallel.fail_fast, state)
+        threads.each_value(&:join)
+
+        apply_captured_variables(state[:captures])
+        raise_first_failure(state[:errors], branches.keys)
+
+        @logger.info("Parallel block completed (branches: #{branches.keys.join(', ')})")
+      ensure
+        kill_lingering_threads(threads, state)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      # State shared by every branch for the duration of one #run call.
+      def new_run_state
+        { cancelled: false, mutex: Mutex.new, captures: {}, errors: {}, branch_results: {} }
+      end
+
+      # Stops any branches already started if starting another one fails,
+      # instead of leaving them running unsupervised. Keyed by branch name
+      # so a later force-kill can tell which branch a thread belongs to.
+      def start_branch_threads(branches, fail_fast, state)
+        threads = {}
+        branches.each do |branch_name, branch_steps|
+          threads[branch_name] = Thread.new { run_branch(branch_name, branch_steps, fail_fast, state) }
+        end
+        threads
+      rescue StandardError
+        kill_lingering_threads(threads, state)
+        raise
+      end
+
+      # Runs one branch's steps sequentially; stops early on its own
+      # failure or when another branch's failure cancels the block.
+      def run_branch(branch_name, branch_steps, fail_fast, state)
+        step_results = []
+        branch, branch_handler = start_branch(branch_name, step_results, state)
+
+        branch_steps.each_with_index do |sub_step, index|
+          break if fail_fast && cancelled?(state)
+
+          step_result = execute_branch_step(branch_handler, branch, sub_step, index)
+          step_results << step_result
+          break if step_result[:status] == 'failed'
+        end
+
+        finish_branch(branch, branch_steps.length, step_results, fail_fast, state)
+      rescue StandardError => e
+        record_branch_results(branch_name, 'failed', step_results, state)
+        record_branch_failure(branch_name, e.message, fail_fast, state)
+      end
+
+      # Sets up one branch's isolated context and step handler. Also records
+      # a 'running' placeholder up front so a forced kill (see
+      # #kill_lingering_threads) still has a `steps` array to report, filled
+      # in as steps finish.
+      def start_branch(branch_name, step_results, state)
+        record_branch_results(branch_name, 'running', step_results, state)
+        branch = Branch.new(name: branch_name, context: BranchContext.new(@context))
+        branch_handler = StepHandler.new(@project, @command_execution_manager, branch.context,
+                                         default_timeout: @default_timeout)
+        [branch, branch_handler]
+      end
+
+      # Runs and times one sub-step, turning a failure into a step result
+      # instead of raising.
+      def execute_branch_step(branch_handler, branch, sub_step, index)
+        desc = branch.context.substitute_variables(sub_step.desc || "Step #{index + 1}")
+        start_time = Time.now
+        status, error = run_sub_step(branch_handler, branch.name, sub_step, index, desc)
+        end_time = Time.now
+
+        { index: index, description: desc, status: status, error: error, start_time: start_time.utc.iso8601,
+          end_time: end_time.utc.iso8601, duration: end_time - start_time }.compact
+      end
+
+      # Runs one sub-step, turning a failure into a [status, error message]
+      # pair instead of raising.
+      def run_sub_step(branch_handler, branch_name, sub_step, index, desc)
+        branch_handler.execute_step(sub_step, index)
+        @logger.info("  [#{branch_name}] PASS: #{desc}")
+        ['passed', nil]
+      rescue StandardError => e
+        @logger.error("  [#{branch_name}] FAIL: #{desc} - #{e.message}")
+        ['failed', e.message]
+      end
+
+      # Determines the branch's final status and, if it succeeded, hands
+      # off its captured variables to be shared with the rest of the test.
+      def finish_branch(branch, total_steps, step_results, fail_fast, state)
+        branch_name = branch.name
+        failed_step = step_results.find { |step_result| step_result[:status] == 'failed' }
+        status = branch_status(failed_step, step_results, total_steps)
+        record_branch_results(branch_name, status, step_results, state)
+
+        if failed_step
+          record_branch_failure(branch_name, failed_step[:error], fail_fast, state)
+          return
+        end
+
+        if status == 'cancelled'
+          @logger.warn("Parallel branch '#{branch_name}' cancelled")
+        else
+          @logger.info("Parallel branch '#{branch_name}' passed")
+        end
+
+        state[:mutex].synchronize { state[:captures][branch_name] = branch.context.pending_captures }
+      end
+
+      # 'cancelled': stopped early because another branch failed (fail_fast).
+      def branch_status(failed_step, step_results, total_steps)
+        return 'failed' if failed_step
+        return 'cancelled' if step_results.length < total_steps
+
+        'passed'
+      end
+
+      def record_branch_results(branch_name, status, step_results, state)
+        state[:mutex].synchronize { state[:branch_results][branch_name] = { status: status, steps: step_results } }
+      end
+
+      # Logs the failure and, for fail_fast blocks, signals every other
+      # branch to stop.
+      def record_branch_failure(branch_name, error_message, fail_fast, state)
+        @logger.error("Parallel branch '#{branch_name}' failed: #{error_message}")
+        state[:mutex].synchronize do
+          state[:errors][branch_name] = error_message
+          state[:cancelled] = true if fail_fast
+        end
+      end
+
+      def cancelled?(state)
+        state[:mutex].synchronize { state[:cancelled] }
+      end
+
+      # Shares every successful branch's captured variables with the rest
+      # of the test. Failed branches never reach here, since they never
+      # hand off captures in the first place.
+      def apply_captured_variables(captures_by_branch)
+        captures_by_branch.each_value do |captures|
+          captures.each { |name, value| @context.set_variable(name, value) }
+        end
+      end
+
+      # Surfaces the first failure by branch declaration order
+      def raise_first_failure(errors, branch_declaration_order)
+        return if errors.empty?
+
+        first_name = branch_declaration_order.find { |name| errors.key?(name) }
+        other_names = errors.keys - [first_name]
+        message = "Parallel branch '#{first_name}' failed: #{errors[first_name]}"
+        message += "; also failed: #{other_names.join(', ')}" unless other_names.empty?
+
+        raise EngineError, message
+      end
+
+      # Force-stops any branch still running after a timeout or abort. A
+      # killed thread never reaches finish_branch on its own, so this also
+      # finalizes its result instead of leaving it missing from the report.
+      def kill_lingering_threads(threads, state)
+        return if threads.nil?
+
+        threads.each do |branch_name, thread|
+          next unless thread.alive?
+
+          @logger.warn("Killing a still-running parallel branch thread (outer timeout or abort): #{branch_name}")
+          thread.kill
+          thread.join(5)
+          finalize_killed_branch(branch_name, state)
+        end
+      end
+
+      # Turns the 'running' placeholder (see #run_branch) into a terminal
+      # status, keeping whatever steps it managed to finish beforehand.
+      def finalize_killed_branch(branch_name, state)
+        state[:mutex].synchronize do
+          result = state[:branch_results][branch_name]
+          result[:status] = 'timeout' if result && result[:status] == 'running'
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/functest/step_handler.rb
+++ b/lib/engines/functest/step_handler.rb
@@ -7,6 +7,9 @@ module AutoHCK
     class StepHandler
       STEP_TYPE_FIELDS = CommandExecutionManager::STEP_TYPE_FIELDS
 
+      # Set after a `parallel` step; nil for every other step type.
+      attr_reader :last_branch_results
+
       def initialize(project, command_execution_manager, context, default_timeout:)
         @project = project
         @command_execution_manager = command_execution_manager
@@ -16,6 +19,7 @@ module AutoHCK
       end
 
       def execute_step(step, step_index)
+        @last_branch_results = nil
         desc = @context.substitute_variables(step.desc || "Step #{step_index + 1}")
         @logger.info("Executing: #{desc}")
 
@@ -23,6 +27,12 @@ module AutoHCK
 
         if step.set_variable
           execute_set_variable(step)
+          return
+        end
+
+        if step.parallel
+          validate_step_type!(step, desc)
+          execute_parallel(step, timeout)
           return
         end
 
@@ -41,6 +51,13 @@ module AutoHCK
       end
 
       private
+
+      def execute_parallel(step, timeout)
+        runner = ParallelBranchRunner.new(@project, @command_execution_manager, @context, @logger, @default_timeout)
+        Timeout.timeout(timeout) { runner.run(step) }
+      ensure
+        @last_branch_results = runner&.branch_results
+      end
 
       def validate_step_type!(step, desc)
         types = STEP_TYPE_FIELDS.select { |field| step.step_type_active?(field) }

--- a/lib/engines/functest/step_handler.rb
+++ b/lib/engines/functest/step_handler.rb
@@ -43,22 +43,9 @@ module AutoHCK
       private
 
       def validate_step_type!(step, desc)
-        types = STEP_TYPE_FIELDS.select { |field| step_type_set?(step, field) }
+        types = STEP_TYPE_FIELDS.select { |field| step.step_type_active?(field) }
         raise EngineError, "No step type set in: #{desc}" if types.empty?
         raise EngineError, "Multiple step types set (#{types.join(', ')}) in: #{desc}" if types.length > 1
-      end
-
-      def step_type_set?(step, field)
-        value = step.public_send(field)
-        case field
-        when :files_action then value.any?
-        when :guest_reboot then value == true
-        when :set_variable then value.is_a?(Hash) && !value.empty?
-        when :guest_run, :guest_run_file, :host_run, :host_run_file, :barrier
-          value.is_a?(String) ? !value.empty? : !value.nil?
-        else
-          !value.nil?
-        end
       end
 
       def execute_set_variable(step)

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -55,7 +55,7 @@ module AutoHCK
         new_test_steps = []
         cycles.times do |cycle|
           test_steps.each do |step|
-            new_step = step.dup
+            new_step = step.deep_dup
             new_step.desc = "[Cycle #{cycle + 1}] #{step.desc}"
             new_test_steps << new_step
           end

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -37,6 +37,11 @@ module AutoHCK
         name.gsub(/[^\w\-.]/, '_').gsub(/(^_|_$)/, '')
       end
 
+      sig { returns(TestCase) }
+      def deep_dup
+        TestCase.from_hash(serialize)
+      end
+
       sig { void }
       def add_auto_index
         pre_test_commands.each_with_index do |step, index|

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -45,6 +45,8 @@ module AutoHCK
 
         test_steps.each_with_index do |step, index|
           step.desc = "[Step #{index + 1}] #{step.desc}"
+          parallel = step.parallel
+          label_branch_steps(parallel, "Step #{index + 1}") if parallel
         end
       end
 
@@ -57,11 +59,34 @@ module AutoHCK
           test_steps.each do |step|
             new_step = step.deep_dup
             new_step.desc = "[Cycle #{cycle + 1}] #{step.desc}"
+            parallel = new_step.parallel
+            prefix_branch_steps(parallel, "Cycle #{cycle + 1}") if parallel
             new_test_steps << new_step
           end
         end
 
         self.test_steps = new_test_steps
+      end
+
+      private
+
+      # Labels parallel sub-steps with the step's own label plus branch name
+      # and position, e.g. "[Step 4][guest_client #1] ...".
+      sig { params(parallel: Models::ParallelBlock, step_label: String).void }
+      def label_branch_steps(parallel, step_label)
+        parallel.branches.each do |branch_name, branch_steps|
+          branch_steps.each_with_index do |sub_step, sub_index|
+            sub_step.desc = "[#{step_label}][#{branch_name} ##{sub_index + 1}] #{sub_step.desc}"
+          end
+        end
+      end
+
+      # Prepends the cycle label to already-labeled parallel sub-steps.
+      sig { params(parallel: Models::ParallelBlock, label: String).void }
+      def prefix_branch_steps(parallel, label)
+        parallel.branches.each_value do |branch_steps|
+          branch_steps.each { |sub_step| sub_step.desc = "[#{label}] #{sub_step.desc}" }
+        end
       end
     end
   end

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -14,6 +14,12 @@ module AutoHCK
 
       RunContext = Struct.new(:clients, :tools, :command_execution_manager, keyword_init: true)
 
+      # Parallel-step constraints; see docs/Functest-Engine.md for details.
+      # Step types allowed inside a parallel branch.
+      PARALLEL_ALLOWED_STEP_TYPES = %i[
+        guest_run guest_run_file files_action host_run host_run_file qmp_command qmp_wait_event
+      ].freeze
+
       # rubocop:disable Metrics/AbcSize
       def initialize(engine, run_context)
         @project = engine.project
@@ -92,10 +98,10 @@ module AutoHCK
           description: test.description,
           test_system_ref: test.test_system_ref,
           timeout: test.timeout,
-          pre_test_commands: test.pre_test_commands.map(&:dup),
+          pre_test_commands: test.pre_test_commands.map(&:deep_dup),
           cycles: test.cycles,
-          test_steps: test.test_steps.map(&:dup),
-          cleanup: test.cleanup.map(&:dup),
+          test_steps: test.test_steps.map(&:deep_dup),
+          cleanup: test.cleanup.map(&:deep_dup),
           clients: test.clients.dup,
           clean_boot: test.clean_boot,
           boot_from_snapshot_tag: test.boot_from_snapshot_tag,
@@ -169,24 +175,142 @@ module AutoHCK
       end
 
       # Sets CommandExecutionManager's default machines to this test's own
-      # clients. Then fails the test right away if any step (including
-      # pre_test_commands and cleanup) targets a client this test didn't
-      # declare.
+      # clients, then fails the test right away if any step (including
+      # pre_test_commands, cleanup, and parallel branches) targets an
+      # undeclared client or violates a parallel execution constraint.
       def prepare_test_clients!(test)
         raise EngineError, "Test '#{test.name}' has an empty clients list" if test.clients.empty?
 
         @command_execution_manager.scope_to_test(test.clients)
         validate_step_clients!(test)
+        validate_parallel_blocks!(test)
+      end
+
+      def all_steps(test)
+        test.pre_test_commands + test.test_steps + test.cleanup
       end
 
       def validate_step_clients!(test)
-        (test.pre_test_commands + test.test_steps + test.cleanup).each do |step|
-          unknown = step.clients - test.clients
-          next if unknown.empty?
+        all_steps(test).each do |step|
+          validate_single_step_clients!(step, test)
+          next unless step.parallel
 
-          raise EngineError, "Test '#{test.name}' step targets client(s) #{unknown.join(', ')} not declared " \
-                             "in this test case's own clients list (#{test.clients.join(', ')})"
+          step.parallel.branches.each_value do |branch_steps|
+            branch_steps.each { |sub_step| validate_single_step_clients!(sub_step, test) }
+          end
         end
+      end
+
+      def validate_single_step_clients!(step, test)
+        unknown = step.clients - test.clients
+        return if unknown.empty?
+
+        raise EngineError, "Test '#{test.name}' step targets client(s) #{unknown.join(', ')} not declared " \
+                           "in this test case's own clients list (#{test.clients.join(', ')})"
+      end
+
+      def validate_parallel_blocks!(test)
+        all_steps(test).each do |step|
+          validate_parallel_block!(step, test) if step.parallel
+        end
+      end
+
+      def validate_parallel_block!(step, test)
+        branches = step.parallel.branches
+        raise EngineError, "Test '#{test.name}': parallel step '#{step.desc}' has no branches" if branches.empty?
+        if branches.length < 2
+          raise EngineError, "Test '#{test.name}': parallel step '#{step.desc}' must have at least two branches"
+        end
+
+        validate_no_conflicting_action!(step)
+        validate_no_nested_parallel!(step, branches)
+        validate_allowed_step_types!(step, branches)
+        validate_no_client_overlap!(step, branches, test)
+        validate_unique_capture_output!(step, branches)
+      end
+
+      def validate_no_conflicting_action!(step)
+        fields = CommandExecutionManager::STEP_TYPE_FIELDS - [:parallel]
+        active = fields.select { |field| step.step_type_active?(field) }
+        return if active.empty?
+
+        raise EngineError, "Step '#{step.desc}': 'parallel' cannot be combined with other step type " \
+                           "field(s): #{active.join(', ')}"
+      end
+
+      def validate_no_nested_parallel!(step, branches)
+        branches.each do |branch_name, branch_steps|
+          next unless branch_steps.any?(&:parallel)
+
+          raise EngineError, "Parallel step '#{step.desc}': branch '#{branch_name}' contains a nested " \
+                             'parallel block, which is not supported'
+        end
+      end
+
+      def validate_allowed_step_types!(step, branches)
+        branches.each do |branch_name, branch_steps|
+          branch_steps.each do |sub_step|
+            active = CommandExecutionManager::STEP_TYPE_FIELDS.select { |field| sub_step.step_type_active?(field) }
+            unless active.one?
+              raise EngineError, "Parallel step '#{step.desc}': branch '#{branch_name}' step must contain " \
+                                 "exactly one step type (found: #{active.join(', ')})"
+            end
+
+            disallowed = active - PARALLEL_ALLOWED_STEP_TYPES
+            next if disallowed.empty?
+
+            raise EngineError, "Parallel step '#{step.desc}': branch '#{branch_name}' contains a forbidden " \
+                               "step type (#{disallowed.join(', ')} not allowed inside parallel branches)"
+          end
+        end
+      end
+
+      def validate_no_client_overlap!(step, branches, test)
+        owner_by_client = {}
+        branches.each do |branch_name, branch_steps|
+          client_ids = branch_steps.flat_map { |sub_step| guest_targeted_clients(sub_step, test) }.uniq
+          raise_client_overlap!(step, branch_name, client_ids, owner_by_client)
+          client_ids.each { |client_id| owner_by_client[client_id] = branch_name }
+        end
+      end
+
+      def raise_client_overlap!(step, branch_name, client_ids, owner_by_client)
+        overlap = client_ids.select { |client_id| owner_by_client.key?(client_id) }
+        return if overlap.empty?
+
+        conflicts = overlap.map { |client_id| "#{client_id} (branch '#{owner_by_client[client_id]}')" }.join(', ')
+        raise EngineError, "Parallel step '#{step.desc}': branch '#{branch_name}' targets client(s) already " \
+                           "targeted by another branch in the same parallel step: #{conflicts}"
+      end
+
+      # Host-only steps target no client. An empty `clients` list broadcasts
+      # to every client declared for the test, same as
+      # CommandExecutionManager's own default.
+      def guest_targeted_clients(sub_step, test)
+        return [] unless sub_step.guest_run || sub_step.guest_run_file || sub_step.files_action.any? ||
+                         sub_step.qmp_command || sub_step.qmp_wait_event
+
+        sub_step.clients.empty? ? test.clients : sub_step.clients
+      end
+
+      # Rejects a capture_output name only when two *different* branches own
+      # it; the same branch reusing a name across its own sequential steps
+      # (last write wins) is normal and not a race.
+      def validate_unique_capture_output!(step, branches)
+        duplicates = capture_output_owners(branches).select { |_name, owners| owners.length > 1 }.keys
+        return if duplicates.empty?
+
+        raise EngineError, "Parallel step '#{step.desc}': duplicate capture_output variable name(s) " \
+                           "across branches: #{duplicates.join(', ')}"
+      end
+
+      # Maps each capture_output name to the set of branches that use it.
+      def capture_output_owners(branches)
+        owners_by_name = Hash.new { |hash, name| hash[name] = Set.new }
+        branches.each do |branch_name, branch_steps|
+          branch_steps.filter_map(&:capture_output).each { |name| owners_by_name[name] << branch_name }
+        end
+        owners_by_name
       end
 
       def execute_test_steps(test, result)
@@ -250,6 +374,9 @@ module AutoHCK
         step_result[:error] = e.message
         @logger.error("  FAIL: #{desc} - #{e.message}")
         raise
+      ensure
+        branch_results = @step_handler.last_branch_results
+        step_result[:branches] = branch_results if branch_results
       end
 
       def log_section(title)

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -89,29 +89,12 @@ module AutoHCK
           'currentcount' => passed + failed + 1, 'total' => total }
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # There is no way to reduce the ABC size of this method without losing clarity.
       def create_local_test_copy(test)
-        TestCase.new(
-          name: test.name,
-          display_name: test.display_name,
-          description: test.description,
-          test_system_ref: test.test_system_ref,
-          timeout: test.timeout,
-          pre_test_commands: test.pre_test_commands.map(&:deep_dup),
-          cycles: test.cycles,
-          test_steps: test.test_steps.map(&:deep_dup),
-          cleanup: test.cleanup.map(&:deep_dup),
-          clients: test.clients.dup,
-          clean_boot: test.clean_boot,
-          boot_from_snapshot_tag: test.boot_from_snapshot_tag,
-          save_snapshot_as: test.save_snapshot_as
-        ).tap do |test_local|
+        test.deep_dup.tap do |test_local|
           test_local.add_auto_index
           test_local.apply_cycles_to_steps
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       def record_test(test)
         start_time = Time.now

--- a/lib/engines/functest/tests/cases/dummy_ci/parallel_host_guest.json
+++ b/lib/engines/functest/tests/cases/dummy_ci/parallel_host_guest.json
@@ -1,0 +1,37 @@
+{
+    "name": "parallel_host_guest",
+    "description": "Run a host command and a guest command in parallel, then verify both branches completed and the guest branch's captured variable was merged after the block",
+    "test_steps": [
+        {
+            "desc": "Run host and guest commands at the same time",
+            "parallel": {
+                "branches": {
+                    "host_branch": [
+                        {
+                            "desc": "Create marker file on host",
+                            "host_run": "touch parallel_ci_host_marker"
+                        }
+                    ],
+                    "guest_branch": [
+                        {
+                            "desc": "Run command in guest",
+                            "guest_run": "Write-Output 'guest_branch_done'",
+                            "capture_output": "guest_marker",
+                            "timeout": 30
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "desc": "Verify host branch created its marker file",
+            "host_run": "test -f parallel_ci_host_marker && echo 'PASS: host marker present'",
+            "expected_output_contains": "PASS:"
+        },
+        {
+            "desc": "Verify guest branch's captured variable is available after the parallel block",
+            "host_run": "test '@guest_marker@' = 'guest_branch_done' && echo 'PASS: guest marker present'",
+            "expected_output_contains": "PASS:"
+        }
+    ]
+}

--- a/lib/engines/functest/tests/suites/dummy.json
+++ b/lib/engines/functest/tests/suites/dummy.json
@@ -1,12 +1,13 @@
 {
     "name": "dummy",
-    "description": "Dummy CI test suite for functest engine validation: snapshot lifecycle, workspace inspection, and variable-to-file",
+    "description": "Dummy CI test suite for functest engine validation: snapshot lifecycle, workspace inspection, variable-to-file, and parallel steps",
     "tests": [
         "dummy_ci/snapshot_create",
         "dummy_ci/snapshot_clean_boot",
         "dummy_ci/snapshot_restore",
         "dummy_ci/workspace_check",
         "dummy_ci/variable_to_file",
-        "dummy_ci/engine_setup_manager_action"
+        "dummy_ci/engine_setup_manager_action",
+        "dummy_ci/parallel_host_guest"
     ]
 }

--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -27,6 +27,7 @@ module AutoHCK
       end
 
       connect(conn)
+      @machine_locks = MachineLocks.new
     end
 
     # A custom ToolsHCK error exception
@@ -75,6 +76,26 @@ module AutoHCK
       def synchronize
         @mutex.synchronize { yield @delegate }
       end
+
+      # For calls that open their own connection per invocation (see
+      # #act_with_tools_on_machine) and so don't need this object's lock.
+      def unsynchronized
+        yield @delegate
+      end
+    end
+
+    # Hands out one mutex per machine name, created on first use. Lets
+    # actions on different machines run concurrently while still
+    # serializing actions against the same machine.
+    class MachineLocks
+      def initialize
+        @mutex = Mutex.new
+        @locks = {}
+      end
+
+      def for_machine(machine)
+        @mutex.synchronize { @locks[machine] ||= Mutex.new }
+      end
     end
 
     def connect(conn)
@@ -97,8 +118,17 @@ module AutoHCK
     end
 
     def act_with_tools(&)
-      results = @tools.synchronize(&)
+      process_tools_result(@tools.synchronize(&))
+    end
 
+    # For actions scoped to one machine: each call opens its own WinRM
+    # connection (see RToolsHCK#machine_connection), so different machines
+    # can run concurrently; only same-machine calls are serialized.
+    def act_with_tools_on_machine(machine, &)
+      process_tools_result(@machine_locks.for_machine(machine).synchronize { @tools.unsynchronized(&) })
+    end
+
+    def process_tools_result(results)
       if results['result'] == 'Failure'
         failure_message = ''
         failure_message = prep_stream_for_log(results['message']) if results['message']
@@ -185,7 +215,7 @@ module AutoHCK
 
     def run_on_machine(machine, desc, cmd)
       retries ||= 0
-      act_with_tools { _1.run_on_machine(machine, cmd) }
+      act_with_tools_on_machine(machine) { _1.run_on_machine(machine, cmd) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       unless (retries += 1) < ACTION_RETRIES
@@ -200,7 +230,7 @@ module AutoHCK
 
     def upload_to_machine(machine, l_directory, r_directory = nil)
       retries ||= 0
-      act_with_tools { _1.upload_to_machine(machine, l_directory, r_directory) }
+      act_with_tools_on_machine(machine) { _1.upload_to_machine(machine, l_directory, r_directory) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       raise UploadToMachineError, "Upload to machine #{machine} failed" unless (retries += 1) < ACTION_RETRIES
@@ -224,7 +254,7 @@ module AutoHCK
 
     def download_from_machine(machine, r_path, l_path)
       retries ||= 0
-      act_with_tools { _1.download_from_machine(machine, r_path, l_path) }
+      act_with_tools_on_machine(machine) { _1.download_from_machine(machine, r_path, l_path) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       raise DownloadFromMachineError, "Download from machine #{machine} failed" unless (retries += 1) < ACTION_RETRIES
@@ -236,7 +266,7 @@ module AutoHCK
 
     def exists_on_machine?(machine, r_path)
       retries ||= 0
-      act_with_tools { _1.exists_on_machine?(machine, r_path) }
+      act_with_tools_on_machine(machine) { _1.exists_on_machine?(machine, r_path) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       raise ExistsOnMachineError, "Checking exists on machine #{machine} failed" unless (retries += 1) < ACTION_RETRIES
@@ -248,7 +278,7 @@ module AutoHCK
 
     def delete_on_machine(machine, r_path)
       retries ||= 0
-      act_with_tools { _1.delete_on_machine(machine, r_path) }
+      act_with_tools_on_machine(machine) { _1.delete_on_machine(machine, r_path) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       raise DeleteOnMachineError, "delete_on_machine #{machine} failed" unless (retries += 1) < ACTION_RETRIES
@@ -264,7 +294,7 @@ module AutoHCK
 
     def restart_machine(machine)
       retries ||= 0
-      act_with_tools { _1.machine_shutdown(machine, restart: true) }
+      act_with_tools_on_machine(machine) { _1.machine_shutdown(machine, restart: true) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       raise RestartMachineError, "Restarting machine #{machine} failed" unless (retries += 1) < ACTION_RETRIES
@@ -276,7 +306,7 @@ module AutoHCK
 
     def shutdown_machine(machine)
       retries ||= 0
-      act_with_tools { _1.machine_shutdown(machine) }
+      act_with_tools_on_machine(machine) { _1.machine_shutdown(machine) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       raise ShutdownMachineError, "Shuting down machine #{machine} failed" unless (retries += 1) < ACTION_RETRIES
@@ -288,7 +318,7 @@ module AutoHCK
 
     def get_machine_system_info(machine, output_format = 'CSV')
       retries ||= 0
-      act_with_tools { _1.get_machine_system_info(machine, output_format) }
+      act_with_tools_on_machine(machine) { _1.get_machine_system_info(machine, output_format) }
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       unless (retries += 1) < ACTION_RETRIES
@@ -324,7 +354,9 @@ module AutoHCK
 
     def install_machine_driver_package(machine, method, driver_path, file, options = {})
       retries ||= 0
-      act_with_tools { _1.install_machine_driver_package(machine, method, driver_path, file, options) }
+      act_with_tools_on_machine(machine) do |tools|
+        tools.install_machine_driver_package(machine, method, driver_path, file, options)
+      end
     rescue ToolsHCKError => e
       @logger.warn(e.message)
       unless (retries += 1) < ACTION_RETRIES

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -136,5 +136,22 @@ module AutoHCK
         end
       end
     end
+
+    # A `parallel` step's named branches that run concurrently. See
+    # docs/Functest-Engine.md for the schema and constraints.
+    class ParallelBlock < T::Struct
+      extend T::Sig
+
+      const :branches, T::Hash[String, T::Array[CommandInfo]]
+
+      # true: the first failure cancels the other branches. false: every
+      # branch runs to completion. Either way, the first failure (by
+      # declaration order) is what gets re-raised.
+      const :fail_fast, T::Boolean, default: true
+    end
+
+    class CommandInfo
+      prop :parallel, T.nilable(ParallelBlock)
+    end
   end
 end

--- a/lib/models/command_info.rb
+++ b/lib/models/command_info.rb
@@ -111,6 +111,30 @@ module AutoHCK
       # JSON's clients map. Empty (default) broadcasts to every client in
       # the current test case.
       const :clients, T::Array[Integer], default: []
+
+      # `dup` is shallow, so array/hash fields would stay shared with the
+      # original. Round-tripping through serialize/from_hash rebuilds every
+      # field (including nested structs) as a new object.
+      sig { returns(CommandInfo) }
+      def deep_dup
+        CommandInfo.from_hash(serialize)
+      end
+
+      # Whether the given step-type field (see
+      # CommandExecutionManager::STEP_TYPE_FIELDS) is set on this step.
+      sig { params(field: Symbol).returns(T::Boolean) }
+      def step_type_active?(field)
+        value = public_send(field)
+        case field
+        when :files_action then value.any?
+        when :guest_reboot then value == true
+        when :set_variable then value.is_a?(Hash) && !value.empty?
+        when :guest_run, :guest_run_file, :host_run, :host_run_file, :barrier
+          value.is_a?(String) ? !value.empty? : !value.nil?
+        else
+          !value.nil?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds a `parallel` step type that runs two or more named branches
concurrently, for tests that need several things happening at once instead of forcing everything
to run one step at a time.

- `ParallelBlock` model and `CommandInfo#step_type_active?` /
  `#deep_dup`, centralizing step-type detection in `CommandInfo`.
- `BranchContext` + `ParallelBranchRunner` execute each branch in its
  own thread and isolated context; captured variables are only shared
  with the rest of the test once every branch finishes.
- Load-time validation (conflicting clients, nested parallel,
  disallowed step types inside a branch, duplicate `capture_output`
  names, etc.) fails fast with a clear error before the test runs.
- `fail_fast` (default `true`) controls whether one branch's failure
  cancels the others; `functest_results.json` reports each branch's
  status and steps individually.
- Docs updated with the new step type's schema, constraints, and
  result format.
- New `dummy_ci` test case exercising a host+guest parallel block in CI.