### PR TITLE
CLI: add --discard-unmap and extend discard=unmap to virtio-scsi-pci

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -98,7 +98,8 @@ Usage: auto_hck.rb test [test options]
                                      Has effect only when testing storage drivers.
         --aio-native                  Use aio=native for virtual disks (forces cache=none, cannot combine with --aio-threads)
         --aio-threads                 Use aio=threads for virtual disks (forces cache=none, cannot combine with --aio-native)
-        --discard-granularity <size>  Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive
+        --discard-unmap               Enable discard=unmap on all virtual drives (virtio-blk-pci and virtio-scsi-pci)
+        --discard-granularity <size>  Set discard_granularity on virtio-blk-pci devices (implies --discard-unmap)
                                      Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)
         --virtiofs-cache <mode>       Set virtiofsd cache mode for the virtio-fs device (default: always)
         --pcie-spare-root-ports <N>   Allocate N extra empty pcie-root-ports at boot for later hotplug (q35 only, default: 0)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -125,12 +125,18 @@ module AutoHCK
     prop :category, T.nilable(String)
     prop :testcase, T.nilable(String)
     prop :drive_aio_state, T.nilable(String)
+    prop :discard_unmap, T::Boolean, default: false
     prop :discard_granularity, T.nilable(String)
     prop :fs_daemon_cache_mode, T.nilable(String)
     prop :virtio_vectors, T.nilable(Integer)
     prop :virtio_queues, T.nilable(Integer)
     prop :pcie_spare_root_ports, T.nilable(Integer)
     prop :test_params, T::Hash[String, String], default: {}
+
+    def apply_discard_granularity(value)
+      self.discard_unmap = true if value
+      self.discard_granularity = value
+    end
 
     def aio_native=(value)
       raise(AutoHCKError, '--aio-native cannot be combined with --aio-threads') if value && drive_aio_state == 'threads'
@@ -326,10 +332,14 @@ module AutoHCK
                 'Use aio=threads for virtual disks (forces cache=none, cannot combine with --aio-native)',
                 &method(:aio_threads=))
 
+      parser.on('--discard-unmap', TrueClass,
+                'Enable discard=unmap on all virtual drives (virtio-blk-pci and virtio-scsi-pci)',
+                &method(:discard_unmap=))
+
       parser.on('--discard-granularity <size>', String,
-                'Set discard_granularity on virtio-blk-pci devices and discard=unmap on their drive',
+                'Set discard_granularity on virtio-blk-pci devices (implies --discard-unmap)',
                 'Size can be a plain byte count or use a K/M/G suffix (e.g. 4096, 4K, 256K, 32M)',
-                &method(:discard_granularity=))
+                &method(:apply_discard_granularity))
 
       parser.on('--virtiofs-cache <mode>', %w[auto always never],
                 'Set virtiofsd cache mode for the virtio-fs device (default: always)',

--- a/lib/setupmanagers/qemuhck/devices/virtio-scsi-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-scsi-pci.json
@@ -10,7 +10,7 @@
     "@source@/bin/fake-snmp-reset @scsi_qmp_socket@ &"
   ],
   "command_line": [
-    "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_scsi_@run_id@_@client_id@@drive_cache_options@",
+    "-drive file=@image_path@,if=none,format=@image_format@,id=virtio_scsi_@run_id@_@client_id@@drive_cache_options@@drive_discard_param@",
     "-device virtio-scsi-pci@device_extra_param@@virtio_scsi_queues_param@@virtio_vectors_param@@iommu_device_param@,id=scsi,bus=@bus_name@.0",
     "-device scsi-hd,drive=virtio_scsi_@run_id@_@client_id@,serial=@client_id@scsi@run_id@@bootindex@",
     "-chardev socket,id=scsi_qmp,path=@scsi_qmp_socket@,server=on,wait=off",

--- a/lib/setupmanagers/qemuhck/qemu_machine.rb
+++ b/lib/setupmanagers/qemuhck/qemu_machine.rb
@@ -426,11 +426,19 @@ module AutoHCK
     DISCARD_GRANULARITY_FORMAT = /\A(\d+)([KMG])?\z/i
     DISCARD_GRANULARITY_UNITS = { 'K' => 1024, 'M' => 1024**2, 'G' => 1024**3 }.freeze
 
-    # Sets discard=unmap and discard_granularity (in bytes) on the virtio-blk-pci
-    # device, when the discard_granularity option is configured.
+    # Sets discard=unmap on drive backends that include @drive_discard_param@
+    # (currently virtio-blk-pci and virtio-scsi-pci) when --discard-unmap is active.
+    # Implied automatically by --discard-granularity via the CLI setter.
+    def drive_discard_replacement_map
+      unmap = option_config('discard_unmap')
+      { '@drive_discard_param@' => (unmap ? ',discard=unmap' : '') }
+    end
+
+    # Sets discard_granularity (in bytes) on the virtio-blk-pci device when
+    # --discard-granularity is given.
     def discard_granularity_replacement_map
       value = option_config('discard_granularity')
-      return { '@drive_discard_param@' => '', '@blk_discard_granularity_param@' => '' } if value.nil?
+      return { '@blk_discard_granularity_param@' => '' } if value.nil?
 
       match = DISCARD_GRANULARITY_FORMAT.match(value.to_s)
       unless match
@@ -440,10 +448,7 @@ module AutoHCK
 
       bytes = match[1].to_i * DISCARD_GRANULARITY_UNITS.fetch(match[2]&.upcase, 1)
 
-      {
-        '@drive_discard_param@' => ',discard=unmap',
-        '@blk_discard_granularity_param@' => ",discard_granularity=#{bytes}"
-      }
+      { '@blk_discard_granularity_param@' => ",discard_granularity=#{bytes}" }
     end
 
     FS_DAEMON_CACHE_MODES = %w[auto always never].freeze
@@ -551,6 +556,7 @@ module AutoHCK
                                              machine_replacement_map,
                                              memory_replacement_map,
                                              options_replacement_map,
+                                             drive_discard_replacement_map,
                                              discard_granularity_replacement_map,
                                              fs_daemon_cache_mode_replacement_map,
                                              virtio_extra_param_replacement_map,

--- a/lib/setupmanagers/qemuhck/qemuhck.rb
+++ b/lib/setupmanagers/qemuhck/qemuhck.rb
@@ -117,6 +117,7 @@ module AutoHCK
         'fs_test_image_format' => test_opt.fs_test_image_format,
         'net_test_speed' => test_opt.net_test_speed,
         'drive_aio_state' => test_opt.drive_aio_state,
+        'discard_unmap' => test_opt.discard_unmap,
         'discard_granularity' => test_opt.discard_granularity,
         'fs_daemon_cache_mode' => test_opt.fs_daemon_cache_mode,
         'virtio_vectors' => test_opt.virtio_vectors,


### PR DESCRIPTION
Add a standalone `--discard-unmap` flag that sets `discard=unmap` on the `-drive `line for both virtio-blk-pci and virtio-scsi-pci devices. 
`--discard-granularity `now implies `--discard-unmap`.