### PR TITLE
functest: add optional display_name field to test cases

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -217,7 +217,8 @@ A test case defines an ordered sequence of steps and optional cleanup steps. Cas
 
 | Field | Required | Description |
 |---|---|---|
-| `name` | Yes | Test case name; shown in results and log output |
+| `name` | Yes | Machine identifier for the test; used in log output, result file names, and suite/CLI references |
+| `display_name` | No | Human-friendly label shown in HTML and JUnit reports instead of `name`. Falls back to `name` when omitted. |
 | `description` | No | Human-readable description |
 | `test_system_ref` | No | Reference to an issue or ticket |
 | `extra_software` | No | List of software packages to install on the guest before any tests run |

--- a/lib/engines/functest/test_case.rb
+++ b/lib/engines/functest/test_case.rb
@@ -9,6 +9,7 @@ module AutoHCK
       extend Models::JsonHelper
 
       const :name, String
+      const :display_name, T.nilable(String)
       const :description, T.nilable(String)
       const :test_system_ref, T.nilable(String)
       const :timeout, T.nilable(Integer)

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -36,13 +36,17 @@ module AutoHCK
         log_section("Starting test: #{test.name}")
         @logger.info("Description: #{@context.substitute_variables(test.description)}") if test.description
 
-        @results << empty_test_result(test.name, test.description) unless @results.any? { |r| r[:name] == test.name }
+        if @results.none? { |r| r[:name] == test.name }
+          @results << empty_test_result(test.name, test.description, display_name: test.display_name)
+        end
         record_test(test)
       end
 
       def execute_tests(tests)
         @logger.info("Executing #{tests.length} test(s)")
-        @results += tests.map { |test| empty_test_result(test.name, test.description) }
+        @results += tests.map do |test|
+          empty_test_result(test.name, test.description, display_name: test.display_name)
+        end
         tests.each { |test| execute_test(test) }
         summary
       end
@@ -64,8 +68,9 @@ module AutoHCK
 
       private
 
-      def empty_test_result(name, description)
-        { name: name, description: description, status: 'not_run', duration: 0, dump_path: nil }
+      def empty_test_result(name, description, display_name: nil)
+        { name: name, display_name: display_name, description: description,
+          status: 'not_run', duration: 0, dump_path: nil }
       end
 
       def tests_stats
@@ -83,6 +88,7 @@ module AutoHCK
       def create_local_test_copy(test)
         TestCase.new(
           name: test.name,
+          display_name: test.display_name,
           description: test.description,
           test_system_ref: test.test_system_ref,
           timeout: test.timeout,

--- a/lib/engines/functest/tests/cases/balloon/balloon_service.json
+++ b/lib/engines/functest/tests/cases/balloon/balloon_service.json
@@ -1,5 +1,6 @@
 {
     "name": "balloon_service",
+    "display_name": "Balloon service can be installed and uninstalled",
     "description": "Install, verify, and uninstall the virtio-balloon Windows service (blnsvr.exe)",
     "test_system_ref": "VIRT-251",
     "timeout": 300,

--- a/lib/engines/functest/tests/cases/driver_package_check.json
+++ b/lib/engines/functest/tests/cases/driver_package_check.json
@@ -1,5 +1,6 @@
 {
     "name": "driver_package_check",
+    "display_name": "Driver package Authenticode signatures are valid",
     "description": "Verify Authenticode signatures of the @driver_module@ driver package (.sys, .cat) before installation",
     "timeout": 60,
     "test_steps": [

--- a/lib/engines/functest/tests/cases/driver_sign_check.json
+++ b/lib/engines/functest/tests/cases/driver_sign_check.json
@@ -1,5 +1,6 @@
 {
     "name": "driver_sign_check",
+    "display_name": "Installed driver is digitally signed",
     "description": "Verify the installed driver .sys is digitally signed (@driver_module@)",
     "test_system_ref": "VIRT-200",
     "timeout": 120,

--- a/lib/engines/functest/tests/cases/driver_signtool_check.json
+++ b/lib/engines/functest/tests/cases/driver_signtool_check.json
@@ -1,5 +1,6 @@
 {
     "name": "driver_signtool_check",
+    "display_name": "Driver catalog integrity verified via signtool",
     "description": "Verify @driver_module@ catalog integrity using signtool — requires extra_software signtool",
     "timeout": 120,
     "test_steps": [

--- a/lib/engines/functest/tests/cases/driver_update.json
+++ b/lib/engines/functest/tests/cases/driver_update.json
@@ -1,5 +1,6 @@
 {
     "name": "driver_update",
+    "display_name": "Driver can be uninstalled and reinstalled",
     "description": "Uninstall and reinstall @driver_module@ from the driver package",
     "test_system_ref": "VIRT-201",
     "timeout": 600,

--- a/lib/models/test_result.rb
+++ b/lib/models/test_result.rb
@@ -11,6 +11,7 @@ module AutoHCK
       include HLK::TestResultStatusPredicates
 
       const :name,             String
+      const :display_name,     T.nilable(String), default: nil
       const :status,           HLK::TestResultStatus, override: true
       const :executionstate,   HLK::ExecutionState
       const :execution_time,   Float
@@ -39,6 +40,7 @@ module AutoHCK
       def self.from_functest(result_hash)
         new(
           name: result_hash[:name],
+          display_name: result_hash[:display_name],
           status: case result_hash[:status]
                   when 'not_run' then HLK::TestResultStatus::NotRun
                   when 'running' then HLK::TestResultStatus::Running

--- a/lib/templates/junit.xml.erb
+++ b/lib/templates/junit.xml.erb
@@ -24,7 +24,7 @@
         <system-err><%= auto_hck_log %></system-err>
 
         <% engine_test_steps.each do |test_step| %>
-            <testcase name="<%= test_step.name %>" classname="HLKTest" time="<%= test_step.execution_time %>">
+            <testcase name="<%= test_step.display_name || test_step.name %>" classname="HLKTest" time="<%= test_step.execution_time %>">
                 <% unless test_step.last_result.nil? %>
                     <system-out><%= JSON.pretty_generate(test_step.last_result) %></system-out>
                 <% end %>

--- a/lib/templates/report.html.erb
+++ b/lib/templates/report.html.erb
@@ -97,8 +97,8 @@
                         <% end %>
                             <th scope="row"><%= row %></th>
                             <td>
-                                <% unless test.url.nil? %><a href="<%= test.url %>"><% end %>
-                                <%= test.name %>
+                                <% unless test.url.nil? %><a href="<%= ERB::Util.html_escape(test.url) %>"><% end %>
+                                <span title="<%= ERB::Util.html_escape(test.name) %>"><%= ERB::Util.html_escape(test.display_name || test.name) %></span>
                                 <% unless test.url.nil? %></a><% end %>
                             </td>
                             <td><%= test.estimatedruntime %></td>


### PR DESCRIPTION
Add an optional display_name field to functest test case JSON files. When present, it replaces the machine name in HTML and JUnit reports, while name remains the stable identifier everywhere else. Falls back to name when omitted.