### PR TITLE
FunctestTools: Wait for WinRM to go offline before declaring reboot complete

### DIFF
--- a/lib/engines/functest/functest_tools.rb
+++ b/lib/engines/functest/functest_tools.rb
@@ -20,12 +20,13 @@ module AutoHCK
     end
 
     # Restart the VM and block until WinRM is reachable again.
-    # Waits WINRM_SETTLE_SLEEP seconds before and after the port check so the
-    # WinRM service has time to fully start before we send the first command.
+    # First waits for WinRM to go down (machine is actually offline), then
+    # waits for it to come back up. This prevents a false positive when the
+    # guest OS shuts down slowly (e.g. with Driver Verifier enabled) and WinRM
+    # is still reachable when we start polling.
     def restart_machine_and_wait(machine)
       restart_machine(machine)
-      @logger.info("Sleeping #{WINRM_SETTLE_SLEEP}s for #{machine} to begin shutdown...")
-      sleep WINRM_SETTLE_SLEEP
+      wait_for_machine_winrm_down(machine)
       wait_for_machine_winrm(machine)
       @logger.info("#{machine} is back after reboot")
     end
@@ -38,6 +39,20 @@ module AutoHCK
     end
 
     private
+
+    def wait_for_machine_winrm_down(machine)
+      addr = @clients_addrs[machine][:addr]
+      port = @clients_addrs[machine][:port] || @config['winrm_port'] || 5985
+      @logger.info("Waiting for #{machine} to go offline...")
+      deadline = Time.now + WAIT_WINRM_TIMEOUT
+      while winrm_port_open?(addr, port)
+        raise RestartMachineError, "#{machine} did not go offline within #{WAIT_WINRM_TIMEOUT}s" \
+          if Time.now > deadline
+
+        sleep WAIT_WINRM_INTERVAL
+      end
+      @logger.debug("#{machine} is now offline")
+    end
 
     def wait_for_machine_winrm(machine)
       addr = @clients_addrs[machine][:addr]


### PR DESCRIPTION
Add wait_for_machine_winrm_down() to poll until the WinRM port closes before waiting for it to come back up. Previously, a slow guest shutdown (e.g. with Driver Verifier enabled) left WinRM reachable when polling started, causing a false positive: the reboot was declared complete without the machine ever going down.

### Related
Solves the bug discovered in test case `pvpanic_with_stop_continue` ([MR !84](https://gitlab.cee.redhat.com/virtio-win/hck-ci/functional-tests/-/merge_requests/84/diffs)).