### PR TITLE
Functest: Bypass Restricted execution policy for guest_run_file

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -300,6 +300,10 @@ Runs an inline command on the client VM via WinRM.
 
 Reads a local script file and executes its content on the client VM. The path is relative to the AutoHCK root.
 
+AutoHCK prepends `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force` so the script can
+dot-source files already on the guest when the image policy is Restricted (for example Win10 x86).
+The override lasts only for that WinRM session; the guest policy is not changed.
+
 ```json
 {
     "desc": "Verify driver is signed",

--- a/lib/auxiliary/command_execution_manager.rb
+++ b/lib/auxiliary/command_execution_manager.rb
@@ -12,6 +12,11 @@ module AutoHCK
     DEFAULT_FILE_ACTION_REMOTE_PATH = 'C:\\'
     DEFAULT_FILE_ACTION_LOCAL_PATH = '@workspace@'
     DEFAULT_TIMEOUT = 300
+    # Lets guest_run_file dot-source .ps1 files on Restricted guests (e.g. Win10 x86).
+    GUEST_RUN_FILE_POLICY_BYPASS = T.let(
+      "Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force\n",
+      String
+    )
 
     RebootStrategy = T.let({
       FixedSleep: :fixed_sleep,
@@ -319,7 +324,7 @@ module AutoHCK
     end
     def resolve_guest_command(command_info, machine_name, replacement)
       command = if command_info.guest_run_file
-                  read_script_file(T.must(command_info.guest_run_file))
+                  "#{GUEST_RUN_FILE_POLICY_BYPASS}#{read_script_file(T.must(command_info.guest_run_file))}"
                 else
                   T.must(command_info.guest_run)
                 end


### PR DESCRIPTION
Win10 x86 Restricted policy blocks dot-sourcing guest helpers from guest_run_file. Prepend a process-scoped ExecutionPolicy Bypass.