### PR TITLE
Functest: Add known issues for suite test cases

### DIFF
--- a/docs/Functest-Engine.md
+++ b/docs/Functest-Engine.md
@@ -187,6 +187,7 @@ A suite is an ordered list of test case references, plus optional metadata. Suit
 | `requirements.drivers` | No | Informational only — not enforced at runtime |
 | `requirements.platforms` | No | Informational only — not enforced at runtime |
 | `reject_test_names` | No | Test case names to always skip when running this suite. Ignored if `--reject-test-names` is passed on the CLI. |
+| `known_issues` | No | Test cases that are known to fail; see [Known Issues](#known-issues) below. |
 
 ### Example
 
@@ -207,6 +208,32 @@ See [`lib/engines/functest/tests/suites/balloon_driver_tests.json`](../lib/engin
         "platforms": [ "Win10x64", "Win2019x64" ]
     }
 }
+```
+
+### Known Issues
+
+Some test cases are known to fail for reasons unrelated to the driver or feature under test. `known_issues` lets a suite declare these ahead of time: a failing test case that matches an entry is reported as **passed with errata** instead of a genuine failure, while still recording why.
+
+Each entry is checked against a test case only after that test case has actually failed — it never masks a step's failure while the test is running, it only changes how the final result is reported.
+
+| Field | Required | Description |
+|---|---|---|
+| `tests` | Yes | List of regexes matched against the test case `name` field (same matching style as extensions' `tests_config`). |
+| `platforms` | No | Platform names (e.g. `"Win2022x64"`) this known issue applies to. Empty (default) matches every platform. |
+| `reason` | Yes | Human-readable explanation of the known issue, shown in the JUnit/HTML reports. |
+
+> `tests` matches the `name` field inside the test case JSON, **not** the path used in a suite. A test at `balloon/balloon_service` has `name` = `balloon_service`.
+
+Granularity is per test case: a test case either matches a known issue or it doesn't.
+
+```json
+"known_issues": [
+    {
+        "tests": ["balloon_service"],
+        "platforms": ["Win2022x64"],
+        "reason": "Balloon service test - known failure on Win2022"
+    }
+]
 ```
 
 ## Test Case Format

--- a/lib/engines/functest/functest.rb
+++ b/lib/engines/functest/functest.rb
@@ -17,7 +17,7 @@ module AutoHCK
     DRIVERS_JSON_DIR = 'lib/engines/hcktest/drivers'
     EXTENSIONS_JSON_DIR = 'lib/engines/hcktest/extensions'
 
-    attr_reader :project, :logger, :drivers, :extensions
+    attr_reader :project, :logger, :drivers, :extensions, :suite
 
     def default_timeout
       @config['default_timeout']

--- a/lib/engines/functest/functest_models.rb
+++ b/lib/engines/functest/functest_models.rb
@@ -4,6 +4,7 @@ module AutoHCK
   module Functest
     extend AutoloadExtension
 
+    autoload_relative :KnownIssue, 'known_issue'
     autoload_relative :Suite, 'suite'
     autoload_relative :TestCase, 'test_case'
   end

--- a/lib/engines/functest/known_issue.rb
+++ b/lib/engines/functest/known_issue.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module AutoHCK
+  module Functest
+    # Declares a known-issue test case failure for a functest suite. Test
+    # cases matching `tests` (by name regex) and `platforms` (current run
+    # platform, empty matches all) are reported as "passed with errata"
+    # instead of a genuine failure when they fail.
+    class KnownIssue < T::Struct
+      extend T::Sig
+
+      const :tests, T::Array[String]
+      const :platforms, T::Array[String], default: []
+      const :reason, String
+    end
+  end
+end

--- a/lib/engines/functest/suite.rb
+++ b/lib/engines/functest/suite.rb
@@ -23,6 +23,7 @@ module AutoHCK
       const :tests, T::Array[String]
       const :requirements, SuiteRequirements, factory: -> { SuiteRequirements.new }
       const :reject_test_names, T::Array[String], default: []
+      const :known_issues, T::Array[KnownIssue], default: []
     end
   end
 end

--- a/lib/engines/functest/test_executor.rb
+++ b/lib/engines/functest/test_executor.rb
@@ -35,6 +35,8 @@ module AutoHCK
         @results = []
         @current_test = nil
         @created_tags = Set.new
+        @known_issues = engine.suite&.known_issues || []
+        @platform_name = engine.project.options.test.platform
       end
       # rubocop:enable Metrics/AbcSize
 
@@ -59,17 +61,18 @@ module AutoHCK
 
       def summary
         total = @results.length
-        passed = @results.count { |r| r[:status] == 'passed' }
-        failed = @results.count { |r| r[:status] == 'failed' }
+        passed, failed, passed_with_known_issue = result_counts
 
         @logger.info('')
         log_section('TEST SUMMARY')
-        @logger.info("Total:  #{total}")
-        @logger.info("Passed: #{passed}")
-        @logger.info("Failed: #{failed}")
+        @logger.info("Total:               #{total}")
+        @logger.info("Passed:              #{passed}")
+        @logger.info("Passed (known issue): #{passed_with_known_issue}") if passed_with_known_issue.positive?
+        @logger.info("Failed:              #{failed}")
         @logger.info('-' * 80)
 
-        { total: total, passed: passed, failed: failed, results: @results }
+        { total: total, passed: passed, failed: failed,
+          passed_with_known_issue: passed_with_known_issue, results: @results }
       end
 
       private
@@ -81,12 +84,22 @@ module AutoHCK
 
       def tests_stats
         total = @results.length
-        passed = @results.count { |r| r[:status] == 'passed' }
-        failed = @results.count { |r| r[:status] == 'failed' }
+        passed, failed, passed_with_known_issue = result_counts
 
         { 'current' => @current_test, 'passed' => passed,
-          'failed' => failed, 'inqueue' => total - passed - failed,
-          'currentcount' => passed + failed + 1, 'total' => total }
+          'passed_with_known_issue' => passed_with_known_issue,
+          'failed' => failed, 'inqueue' => total - passed - passed_with_known_issue - failed,
+          'currentcount' => passed + passed_with_known_issue + failed + 1, 'total' => total }
+      end
+
+      # [passed, failed, passed_with_known_issue] counts. A result counts as
+      # passed/failed only when it has no known_issue; known_issue results are
+      # reported separately regardless of their underlying pass/fail status.
+      def result_counts
+        passed = @results.count { |r| r[:status] == 'passed' && r[:known_issue].nil? }
+        failed = @results.count { |r| r[:status] == 'failed' && r[:known_issue].nil? }
+        passed_with_known_issue = @results.count { |r| !r[:known_issue].nil? }
+        [passed, failed, passed_with_known_issue]
       end
 
       def create_local_test_copy(test)
@@ -115,6 +128,7 @@ module AutoHCK
         @project.update_test_stats(tests_stats)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def finalize_result(result, test, start_time)
         run_cleanup(test)
         begin
@@ -129,9 +143,12 @@ module AutoHCK
         result[:end_time] = end_time.utc.iso8601
         result[:duration] = end_time - start_time
 
+        apply_known_issue_if_failed(test.name, result)
+
         @results.find { |r| r[:name] == test.name }.merge!(result)
         save_result(result, test)
       end
+      # rubocop:enable Metrics/AbcSize
 
       def save_result(result, test)
         r_name = "Result_#{test.safe_name}.json"
@@ -404,6 +421,26 @@ module AutoHCK
           regex = (@extension_test_regexes[config] ||= Regexp.union(config.tests.map { Regexp.new(_1) }))
           regex.match?(test_name)
         end.flat_map(&type)
+      end
+
+      # Suite-declared known issues matching this test name and the current
+      # platform. An empty `platforms` list on the entry matches every platform.
+      def matching_known_issues(test_name)
+        @known_issues.select do |known_issue|
+          regex = Regexp.union(known_issue.tests.map { Regexp.new(_1) })
+          regex.match?(test_name) &&
+            (known_issue.platforms.empty? || known_issue.platforms.include?(@platform_name))
+        end
+      end
+
+      def apply_known_issue_if_failed(test_name, result)
+        return unless result[:status] == 'failed'
+
+        known_issue = matching_known_issues(test_name).first
+        return unless known_issue
+
+        @logger.info("Test '#{test_name}' failed but has a known issue: #{known_issue.reason}")
+        result[:known_issue] = known_issue.reason
       end
 
       def run_extension_pre_test_commands(test_name)

--- a/lib/models/test_result.rb
+++ b/lib/models/test_result.rb
@@ -51,7 +51,7 @@ module AutoHCK
           executionstate: HLK::ExecutionState::NotRunning,
           execution_time: result_hash[:duration].to_f,
           is_skipped: false,
-          errata: nil,
+          errata: result_hash[:known_issue],
           last_result: result_hash,
           dump_path: result_hash[:dump_path],
           url: nil,


### PR DESCRIPTION
Suites can now declare `known_issues` entries (test name regex, optional platforms, and a reason). A matching test case that fails is reported as passed with errata instead of a genuine failure, while still recording why.