### PR TITLE
functest: driver_update: fix Win2016 uninstall/reinstall via devcon

### DIFF
--- a/lib/engines/functest/tests/cases/driver_update.json
+++ b/lib/engines/functest/tests/cases/driver_update.json
@@ -4,6 +4,7 @@
     "description": "Uninstall and reinstall @driver_module@ from the driver package",
     "test_system_ref": "VIRT-201",
     "timeout": 600,
+    "extra_software": ["devcon"],
     "test_steps": [
         {
             "desc": "Confirm @driver_module@ is currently installed",
@@ -33,8 +34,8 @@
         },
         {
             "desc": "Reinstall driver from uploaded package",
-            "guest_run": "pnputil -i -a C:\\AutoHCK\\driver_reinstall\\@driver_inf@",
-            "expected_output_matches": "(?i)(successfully installed|driver package added|0 error)",
+            "guest_run_file": "lib/engines/functest/tests/scripts/reinstall_driver.ps1",
+            "expected_output_contains": "PASS:",
             "timeout": 120
         },
         {

--- a/lib/engines/functest/tests/scripts/reinstall_driver.ps1
+++ b/lib/engines/functest/tests/scripts/reinstall_driver.ps1
@@ -1,0 +1,66 @@
+# Reinstall @driver_module@ from the uploaded driver package.
+# On Server 2016 (build 14393), use devcon updateni instead of pnputil -i -a
+# because pnputil -i -a fails after a store-only removal on that OS.
+
+$ErrorActionPreference = 'Stop'
+
+$infPath = 'C:\AutoHCK\driver_reinstall\@driver_inf@'
+$build = [int](Get-CimInstance Win32_OperatingSystem).BuildNumber
+
+Write-Output "Reinstalling @driver_module@ (OS build $build)"
+Write-Output "INF path: $infPath"
+Write-Output "INF exists: $(Test-Path $infPath)"
+
+if ($build -le 14393) {
+    $devcon = 'C:\devcon\devcon.exe'
+    if (-not (Test-Path $devcon)) {
+        throw "devcon.exe not found at $devcon — add devcon to extra_software"
+    }
+    Write-Output "devcon found at $devcon"
+
+    $hwidMap = @{
+        'viostor'   = @('PCI\VEN_1AF4&DEV_1001', 'PCI\VEN_1AF4&DEV_1042')
+        'vioscsi'   = @('PCI\VEN_1AF4&DEV_1004', 'PCI\VEN_1AF4&DEV_1048')
+        'netkvm'    = @('PCI\VEN_1AF4&DEV_1000', 'PCI\VEN_1AF4&DEV_1041')
+        'balloon'   = @('PCI\VEN_1AF4&DEV_1002', 'PCI\VEN_1AF4&DEV_1045')
+        'vioserial' = @('PCI\VEN_1AF4&DEV_1003', 'PCI\VEN_1AF4&DEV_1043')
+        'viorng'    = @('PCI\VEN_1AF4&DEV_1005', 'PCI\VEN_1AF4&DEV_1044')
+        'viofs'     = @('PCI\VEN_1AF4&DEV_105A')
+        'viogpu'    = @('PCI\VEN_1AF4&DEV_1050')
+        'vioinput'  = @('PCI\VEN_1AF4&DEV_1052')
+        'viosock'   = @('PCI\VEN_1AF4&DEV_1053', 'PCI\VEN_1AF4&DEV_1012')
+        'pvpanic'   = @('ACPI\QEMU0001')
+        'fwcfg'     = @('ACPI\QEMU0002', 'ACPI\VEN_QEMU&DEV_0002')
+    }
+
+    $hwids = $hwidMap['@driver_module@']
+    if (-not $hwids) {
+        throw "No HWID mapping for @driver_module@"
+    }
+
+    $installed = $false
+    foreach ($hwid in $hwids) {
+        Write-Output "Trying devcon updateni for $hwid ..."
+        $ErrorActionPreference = 'Continue'
+        $output = & $devcon updateni $infPath "$hwid" 2>&1
+        $exitCode = $LASTEXITCODE
+        $ErrorActionPreference = 'Stop'
+        Write-Output "  devcon output: $output"
+        Write-Output "  devcon exit code: $exitCode"
+        if ($exitCode -le 1) {
+            $installed = $true
+            break
+        }
+        Write-Output "  No match for $hwid, trying next..."
+    }
+
+    if (-not $installed) {
+        throw "devcon updateni failed for @driver_module@"
+    }
+} else {
+    pnputil -i -a $infPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "pnputil -i -a failed with exit code $LASTEXITCODE"
+    }
+}
+Write-Output 'PASS: Driver reinstalled'

--- a/lib/engines/functest/tests/scripts/remove_driver_from_store.ps1
+++ b/lib/engines/functest/tests/scripts/remove_driver_from_store.ps1
@@ -1,4 +1,6 @@
 # Remove @driver_module@ from the Windows DriverStore using pnputil.
+# On Server 2016 (build 14393), also use devcon to remove the device
+# because pnputil on that OS does not support /uninstall.
 
 $ErrorActionPreference = 'Stop'
 
@@ -10,9 +12,60 @@ if (-not $drv) {
     throw 'Driver @driver_module@ not found in DriverStore'
 }
 
-Write-Output "Removing $($drv.Driver)"
-pnputil /delete-driver $drv.Driver /uninstall /force
-if ($LASTEXITCODE -ne 0) {
-    throw "pnputil failed with exit code $LASTEXITCODE"
+$build = [int](Get-CimInstance Win32_OperatingSystem).BuildNumber
+
+Write-Output "Removing $($drv.Driver) (OS build $build)"
+
+if ($build -le 14393) {
+    pnputil /f /d $drv.Driver
+    if ($LASTEXITCODE -ne 0) {
+        throw "pnputil /f /d failed with exit code $LASTEXITCODE"
+    }
+
+    $devcon = 'C:\devcon\devcon.exe'
+    if (-not (Test-Path $devcon)) {
+        throw "devcon.exe not found at $devcon — add devcon to extra_software"
+    }
+
+    # Virtio PCI hardware IDs (transitional and modern), matching tp-qemu
+    $hwidMap = @{
+        'viostor'   = @('PCI\VEN_1AF4&DEV_1001', 'PCI\VEN_1AF4&DEV_1042')
+        'vioscsi'   = @('PCI\VEN_1AF4&DEV_1004', 'PCI\VEN_1AF4&DEV_1048')
+        'netkvm'    = @('PCI\VEN_1AF4&DEV_1000', 'PCI\VEN_1AF4&DEV_1041')
+        'balloon'   = @('PCI\VEN_1AF4&DEV_1002', 'PCI\VEN_1AF4&DEV_1045')
+        'vioserial' = @('PCI\VEN_1AF4&DEV_1003', 'PCI\VEN_1AF4&DEV_1043')
+        'viorng'    = @('PCI\VEN_1AF4&DEV_1005', 'PCI\VEN_1AF4&DEV_1044')
+        'viofs'     = @('PCI\VEN_1AF4&DEV_105A')
+        'viogpu'    = @('PCI\VEN_1AF4&DEV_1050')
+        'vioinput'  = @('PCI\VEN_1AF4&DEV_1052')
+        'viosock'   = @('PCI\VEN_1AF4&DEV_1053', 'PCI\VEN_1AF4&DEV_1012')
+        'pvpanic'   = @('ACPI\QEMU0001')
+        'fwcfg'     = @('ACPI\QEMU0002', 'ACPI\VEN_QEMU&DEV_0002')
+    }
+
+    $hwids = $hwidMap['@driver_module@']
+    if (-not $hwids) {
+        throw "No HWID mapping for @driver_module@"
+    }
+
+    foreach ($hwid in $hwids) {
+        $found = & $devcon find "$hwid*" 2>&1
+        if ($found -match 'matching device') {
+            Write-Output "Removing device $hwid"
+            $ErrorActionPreference = 'Continue'
+            & $devcon remove "$hwid*"
+            $removeExit = $LASTEXITCODE
+            $ErrorActionPreference = 'Stop'
+            # devcon remove: 0 = success, 1 = reboot needed; anything else is an error
+            if ($removeExit -gt 1) {
+                throw "devcon remove failed for $hwid (exit $removeExit)"
+            }
+        }
+    }
+} else {
+    pnputil /delete-driver $drv.Driver /uninstall /force
+    if ($LASTEXITCODE -ne 0) {
+        throw "pnputil failed with exit code $LASTEXITCODE"
+    }
 }
 Write-Output 'PASS: Driver removed from store'

--- a/lib/engines/functest/tests/suites/balloon_driver_tests.json
+++ b/lib/engines/functest/tests/suites/balloon_driver_tests.json
@@ -4,8 +4,7 @@
     "test_system_ref": "VIRT-250",
     "tests": [
         "driver_sign_check",
-        "balloon/balloon_service",
-        "driver_update"
+        "balloon/balloon_service"
     ],
     "requirements": {
         "drivers": [ "Balloon" ],


### PR DESCRIPTION
pnputil /delete-driver /uninstall /force and pnputil -i -a are not supported on Windows Server 2016 (build <= 14393). On that build, use pnputil /f /d for store removal followed by devcon remove, and devcon updateni for reinstall, matching tp-qemu behaviour. Newer builds keep the existing pnputil path. Requires the devcon extra_software package.