### PR TITLE
HCKTest: Add --package-exclude-unreferenced-files option

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -59,6 +59,8 @@ Usage: auto_hck.rb test [test options]
                                      Test results table can be broken. (experimental)
         --manual                     Run AutoHCK in manual mode
         --package-with-playlist      Load playlist into HLKX project package
+        --package-exclude-unreferenced-files
+                                     Exclude driver files not referenced by the driver's .inf before packaging
     -h, --help                       Show this message
 Usage: auto_hck.rb install [install options]
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -99,6 +99,7 @@ module AutoHCK
     prop :manual, T::Boolean, default: false
     prop :auto_manual, T::Boolean, default: false
     prop :package_with_playlist, T::Boolean, default: false
+    prop :package_exclude_unreferenced_files, T::Boolean, default: false
     prop :enable_vbs, T::Boolean, default: false
     prop :tag_suffix, T.nilable(String)
     prop :fs_test_image_format, String, default: 'qcow2'
@@ -146,6 +147,10 @@ module AutoHCK
                 'Use --package-with-driver=unsigned to remove signature from the driver before including') do |pa|
         self.package_with_driver = pa || :keep
       end
+
+      parser.on('--package-exclude-unreferenced-files', TrueClass,
+                'Exclude driver files not referenced by the driver .inf before packaging',
+                &method(:package_exclude_unreferenced_files=))
 
       parser.on('-c', '--commit <commit_hash>', String,
                 'Commit hash for CI status update',

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -674,7 +674,8 @@ module AutoHCK
       remote_supplemental_path = prepare_package_supplemental_content
 
       res = @tools.create_project_package(@tag, package_playlist, nil, remote_driver_path, remote_supplemental_path,
-                                          remove_driver_signatures: test_options.package_with_driver == :unsigned)
+                                          remove_driver_signatures: test_options.package_with_driver == :unsigned,
+                                          exclude_unreferenced_files: test_options.package_exclude_unreferenced_files)
       print_project_package_results(res)
 
       r_name = @tag + File.extname(res['hostprojectpackagepath'])

--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -382,11 +382,11 @@ module AutoHCK
     end
 
     def create_project_package(project, playlist = nil, handler = nil, driver_path = nil, supplemental_path = nil, # rubocop:disable Metrics/ParameterLists
-                               remove_driver_signatures: false)
+                               remove_driver_signatures: false, exclude_unreferenced_files: false)
       retry_tools_command(__method__) do
         act_with_tools do |tools|
           tools.create_project_package(project, playlist, handler, driver_path, supplemental_path,
-                                       remove_driver_signatures:)
+                                       remove_driver_signatures:, exclude_unreferenced_files:)
         end
       end
     end


### PR DESCRIPTION
Pass the new exclude_unreferenced_files flag through the tools chain to rtoolsHCK's create_project_package so drivers can be packaged without files not referenced by their INF.