### PR TITLE
Add virtio-mouse-pci and virtio-tablet-pci device configs

### DIFF
--- a/lib/setupmanagers/qemuhck/devices/virtio-mouse-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-mouse-pci.json
@@ -1,0 +1,5 @@
+{
+  "name": "virtio-mouse-pci",
+  "need_pci_bus": true,
+  "command_line": ["-device virtio-mouse-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,bus=@bus_name@.0"]
+}

--- a/lib/setupmanagers/qemuhck/devices/virtio-tablet-pci.json
+++ b/lib/setupmanagers/qemuhck/devices/virtio-tablet-pci.json
@@ -1,0 +1,5 @@
+{
+  "name": "virtio-tablet-pci",
+  "need_pci_bus": true,
+  "command_line": ["-device virtio-tablet-pci@device_extra_param@@virtio_vectors_param@@iommu_device_param@,bus=@bus_name@.0"]
+}


### PR DESCRIPTION
These device configs enable vioinput mouse and tablet testing in HCK-CI. Following the same pattern as virtio-keyboard-pci.