### PR TITLE
CmdRun: join pipe reader threads before close returns

### DIFF
--- a/lib/auxiliary/cmd_run.rb
+++ b/lib/auxiliary/cmd_run.rb
@@ -11,6 +11,7 @@ module AutoHCK
       @exception = exception
       @logger = logger
       @stddata = { 'stdout' => [], 'stderr' => [], 'both' => [] }
+      @pipe_threads = []
 
       scope.transaction do |transaction|
         ResourceScope.open do |tmp|
@@ -27,6 +28,7 @@ module AutoHCK
     def close
       if @status.nil?
         @status = Process.wait2(@pid)[1]
+        @pipe_threads.each(&:join)
         e_message = "Failed to run (PID #{@pid}) (exit code #{@status.exitstatus}): #{@cmd}"
         raise CmdRunError, e_message if @exception && !@status.exitstatus.zero?
 
@@ -46,7 +48,7 @@ module AutoHCK
       read, write = IO.pipe
       scope << write
 
-      Thread.new do
+      thread = Thread.new do
         read.each(chomp: true) do |data|
           log "#{name}: #{data}".encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
           @stddata[name] << data
@@ -55,6 +57,7 @@ module AutoHCK
       ensure
         read.close
       end
+      @pipe_threads << thread
 
       write
     end

--- a/spec/lib/auxiliary/cmd_run_spec.rb
+++ b/spec/lib/auxiliary/cmd_run_spec.rb
@@ -72,6 +72,16 @@ describe AutoHCK::CmdRun, :linux_process do
         expect(cmd.close.exitstatus).to eq(1)
       end
     end
+
+    it 'buffers all stdout before close returns (pipe reader threads joined)' do
+      AutoHCK::ResourceScope.open([]) do |scope|
+        cmd = new_cmd(scope, '/bin/bash', '-c',
+                      'for i in $(seq 1 50); do echo "line $i"; sleep 0.01; done; echo PASS: done')
+        cmd.close
+        expect(cmd.stddata['stdout']).to include('PASS: done')
+        expect(cmd.stddata['stdout'].size).to be >= 51
+      end
+    end
   end
 
   describe 'spawn options' do


### PR DESCRIPTION
## Summary

`CmdRun#close` waited for the child process with `Process.wait2`, then returned immediately while stdout/stderr were still being read in background threads. Callers that inspect `stddata` right after `close` could see incomplete output.

This showed up in functest host commands (e.g. `ping -c 10`): the command succeeded and printed `PASS:`, but validation ran before the last lines were buffered, causing false failures like `expected to contain 'PASS:'`.

## Fix

- Track stdout/stderr pipe reader threads in `@pipe_threads`
- Join those threads in `close` after `wait2` and before returning

## Test

Add a spec that runs slow stdout and asserts `stddata['stdout']` is complete when `close` returns (no polling). Existing `cmd_run_spec` tests check exit status and logging, but do not cover this race.

## Test plan

- [x] `bundle exec rspec spec/lib/auxiliary/cmd_run_spec.rb` — 8 examples, 0 failures

